### PR TITLE
fix(tui, middlewares): plugin command execution no longer overwrites user input

### DIFF
--- a/peri-middlewares/src/subagent/skill_preload.rs
+++ b/peri-middlewares/src/subagent/skill_preload.rs
@@ -13,9 +13,11 @@ use crate::skills::{list_skills, load_global_skills_dir};
 /// 支持格式：
 /// - `/skill-name` — 单个 skill
 /// - `/skill-a /skill-b` — 多个 skill（空格分隔）
+/// - `/namespace:skill-name` — 带命名空间的 skill
 /// - 消息中任意位置出现即可（不限于行首）
 ///
-/// 仅匹配由 `/` 开头、后跟 `[a-zA-Z0-9_-]` 的 token。
+/// 匹配由 `/` 开头、后跟 `[a-zA-Z0-9_:.-]` 的 token。
+/// 允许 `:` 以支持插件命名空间（如 `/ecc:plan`）。
 pub fn extract_skill_names_from_text(text: &str) -> Vec<String> {
     text.split_whitespace()
         .filter_map(|word| {
@@ -23,7 +25,7 @@ pub fn extract_skill_names_from_text(text: &str) -> Vec<String> {
             if !name.is_empty()
                 && name
                     .chars()
-                    .all(|c| c.is_alphanumeric() || c == '-' || c == '_')
+                    .all(|c| c.is_alphanumeric() || c == '-' || c == '_' || c == ':' || c == '.')
             {
                 Some(name.to_string())
             } else {
@@ -122,7 +124,15 @@ impl<S: State> Middleware<S> for SkillPreloadMiddleware {
             let all_skills = list_skills(&dirs);
             all_skills
                 .into_iter()
-                .filter(|s| names_lower.contains(&s.name.to_lowercase()))
+                .filter(|s| {
+                    let skill_name_lower = s.name.to_lowercase();
+                    names_lower.iter().any(|name| {
+                        // 精确匹配（/plan）
+                        skill_name_lower == *name
+                        // 或去掉命名空间前缀后匹配（/ecc:plan → plan）
+                        || name.rsplit_once(':').map(|(_, n)| n.to_lowercase()) == Some(skill_name_lower.clone())
+                    })
+                })
                 .filter_map(|s| {
                     let content = std::fs::read_to_string(&s.path).ok()?;
                     Some((s.path.to_string_lossy().to_string(), content))

--- a/peri-tui/src/command/session/plugin_command.rs
+++ b/peri-tui/src/command/session/plugin_command.rs
@@ -1,6 +1,6 @@
 use crate::app::App;
 use crate::command::Command;
-use peri_middlewares::plugin::{CommandEntry, CommandSource};
+use peri_middlewares::plugin::CommandEntry;
 
 /// 将插件的 CommandEntry 适配为 TUI Command trait
 pub struct PluginCommandAdapter {
@@ -20,17 +20,16 @@ impl Command for PluginCommandAdapter {
     fn description(&self, _lc: &crate::i18n::LcRegistry) -> String {
         self.entry.description.clone()
     }
-    fn execute(&self, app: &mut App, _args: &str) {
-        match &self.entry.source {
-            CommandSource::Plugin { path } => {
-                if let Ok(content) = std::fs::read_to_string(path) {
-                    app.active_mut().ui.textarea.insert_str(&content);
-                } else {
-                    tracing::warn!(path = %path.display(), "读取插件命令文件失败");
-                }
-            }
-            CommandSource::Builtin => {}
-        }
+    fn execute(&self, app: &mut App, args: &str) {
+        // 插件命令的行为是触发对应的 skill 预加载。
+        // 保持用户原始输入（含命名空间前缀），让 SkillPreloadMiddleware 识别。
+        let message = if args.is_empty() {
+            format!("/{}", self.entry.name)
+        } else {
+            format!("/{} {}", self.entry.name, args)
+        };
+
+        app.submit_message(message);
     }
 }
 


### PR DESCRIPTION
## Summary | 摘要

This PR fixes a bug where plugin commands (e.g. `/ecc:plan`) would overwrite the user's input
with the raw command file content (including YAML frontmatter), instead of submitting the
user's intended message. #10

本 PR 修复了一个 bug：当使用插件命令（如 `/ecc:plan`）时，命令文件的原始内容（包含 YAML
frontmatter）会覆盖用户输入，而非提交用户的实际意图消息。

## Bug Description | Bug 描述

**Before | 修复前:**

When a user typed `/ecc:plan` and pressed Enter, `PluginCommandAdapter::execute()` read the
command markdown file (e.g. `commands/plan.md`) and inserted its **entire raw content** into
the textarea. This caused:

- The user's original message to be **completely overwritten**
- YAML frontmatter (e.g. `---\nname: plan\ndescription: ...\n---`) to be displayed in the input
box
- The skill's markdown body to be sent as a plain text message, bypassing the
`SkillPreloadMiddleware` mechanism

当用户输入 `/ecc:plan` 并按 Enter 后，`PluginCommandAdapter::execute()` 会读取命令的 markdown
文件（如 `commands/plan.md`）并将其**完整原始内容**插入输入框。这导致：

- 用户原始消息被**完全覆盖**
- YAML frontmatter（如 `---\nname: plan\ndescription: ...\n---`）显示在输入框中
- skill 的 markdown 正文被作为纯文本消息发送，绕过了 `SkillPreloadMiddleware` 机制

**After | 修复后:**

Plugin commands now submit the user's **original input** (e.g. `/ecc:plan`), allowing
`SkillPreloadMiddleware` to detect the namespaced skill name and preload the skill content
properly as `ToolUse`/`ToolResult` messages.

插件命令现在提交用户的**原始输入**（如 `/ecc:plan`），让 `SkillPreloadMiddleware`
正确检测带命名空间的 skill 名称，并以 `ToolUse`/`ToolResult` 消息形式预加载 skill 内容。

## Changes | 变更

### 1. `peri-tui/src/command/session/plugin_command.rs`
- **Changed** `PluginCommandAdapter::execute()` to submit the user's original input message
(`/ecc:plan`) via `app.submit_message()`, instead of inserting the command file content into
the textarea.
- Removed dependency on `CommandSource` (no longer needs to read the file path).

- **修改** `PluginCommandAdapter::execute()` 为通过 `app.submit_message()`
提交用户原始输入消息（`/ecc:plan`），而非将命令文件内容插入输入框。
- 移除了对 `CommandSource` 的依赖（不再需要读取文件路径）。

### 2. `peri-middlewares/src/subagent/skill_preload.rs`
- **Updated** `extract_skill_names_from_text()` to allow `:` and `.` characters in skill names,
enabling namespaced skill detection (e.g. `ecc:plan`).
- **Updated** skill name matching logic to support both:
- Exact match: `plan` → `plan`
- Namespace-stripped match: `ecc:plan` → `plan`

- **更新** `extract_skill_names_from_text()` 允许 skill 名称中包含 `:` 和 `.`
字符，以支持带命名空间的 skill 检测（如 `ecc:plan`）。
- **更新** skill 名称匹配逻辑以支持：
- 精确匹配：`plan` → `plan`
- 去掉命名空间前缀匹配：`ecc:plan` → `plan`