### PR TITLE
docs(README): 重写 README，对齐 cc-hooks 风格

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,64 +1,118 @@
+<div align="center">
+
+**中文** | [English](README_EN.md)
+
 # Peri
 
-Peri is a terminal coding agent, built the **Nobody Coding** way — powered by **DeepSeek-V4-Pro** and **GLM-5.1**. Peri is compatible with Claude Code — your `.claude/` config just works. It grew out of [OpenLangGraphServer](https://github.com/konghayao/open-langgraph-server) and [Zen Code](https://github.com/konghayao/zen-code). Built in Rust, runs on my little RISC-V dev board.
+**用开源模型跑 Agent Loop — Rust 写的终端编程助手，兼容 Claude Code 全家桶**
 
-> Recent commits are almost entirely DeepSeek and GLM. Claude was just there in the beginning.
+DeepSeek-V4-Pro + GLM-5.1 驱动，`.claude/` 配置零迁移，RISC-V 也能跑。
 
-## Why Peri
+[![GitHub stars](https://img.shields.io/github/stars/konghayao/peri?style=social)](https://github.com/konghayao/peri/stargazers)
+[![License](https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square)](LICENSE)
 
-- **Rust, not Node.js or Bun.** Fast startup, ~50MB memory footprint, no runtime overhead. Won't sneak up to 1GB while you're not looking.
-- **Context optimized.** System prompt frozen at session start, dynamic content isolated behind a boundary marker, tool definitions stable across rounds.
-  - 95-99% prompt cache hit rate — minimal token waste.
-  - No agent memory / auto-dream / extra calls to waste your tokens.
-  - Only core tools in every request. Other tools lazy-loaded on demand using Tool Search.
-- **Any LLM, not just one.** Anthropic, OpenAI-compatible APIs — DeepSeek, GLM, whatever works for you.
-- **Drop-in compatible.** Your `.claude/` config just works. Zero migration.
-  - Agents, skills, hooks, and MCP servers.
-  - Plugins from the Claude Code ecosystem.
-  - Sub-agents with the same `.claude/agents/` definitions.
-  - Auto compact — long sessions stay fast and cheap.
-- **Streaming Markdown.** Full Markdown rendering as the agent types — code blocks, tables, diffs, all live.
-- **IDE-ready via [ACP](https://github.com/Azure/agent-client-protocol).** Connects to [Zed](https://zed.dev) and other ACP clients out of the box. We're also building a "Cloud Code" platform where any ACP-compatible agent can plug in and go.
-- **Unchecked but ready.**
-  - Built-in LSP.
-  - Built-in split screen.
-  - Background agents: fork work to sub-agents that run while you keep going.
+[为什么选 Peri](#为什么选-peri) · [核心能力](#核心能力) · [安装](#安装) · [Nobody Coding](#我们怎么用-nobody-coding-造-peri) · [致谢](#致谢)
 
-## Install
+</div>
 
-Binaries available for macOS (x86_64 / Apple Silicon), Linux (x86_64 / aarch64 / riscv64), and Windows (x86_64).
+---
+
+## 为什么选 Peri？
+
+| 对比项 | 其他终端 Agent | Peri |
+|--------|---------------|------|
+| 运行时 | Node.js / Bun，动辄吃 1GB 内存 | Rust 原生，启动快，~50MB 内存 |
+| 模型绑定 | 锁死一家 LLM | 随便换：Anthropic、OpenAI 兼容、DeepSeek、GLM |
+| Prompt 缓存 | 每轮重算，token 白烧 | 冻结 system prompt，95-99% 缓存命中率 |
+| 工具加载 | 全量塞进每轮请求 | 核心工具常驻，其余 Tool Search 按需懒加载 |
+| IDE 集成 | 只有终端 | ACP 协议，Zed 等 IDE 直连 |
+| Claude Code 生态 | 不兼容 | 直接用 `.claude/` 配置、agents、skills、hooks、MCP |
+
+---
+
+## 核心能力
+
+| 能力 | 说明 |
+|------|------|
+| **Rust 原生** | 快启动、低内存、零运行时开销 |
+| **Context 优化** | system prompt 冻结 + 动态内容隔离，token 不浪费 |
+| **多 LLM 支持** | Anthropic / OpenAI 兼容 API，DeepSeek、GLM 随便切 |
+| **Claude Code 兼容** | `.claude/` 配置、agents、skills、hooks、MCP、子 agent 直接复用 |
+| **流式 Markdown** | 代码块、表格、diff 实时渲染 |
+| **ACP 协议** | 接入 Zed 等 IDE，也支持自建 "Cloud Code" 平台 |
+| **Auto Compact** | 长会话自动压缩，保持响应快且省 token |
+| **实验功能** | 内置 LSP、分屏、后台子 agent 并行 |
+
+---
+
+## 安装
+
+支持 macOS (x86_64 / Apple Silicon)、Linux (x86_64 / aarch64 / riscv64)、Windows (x86_64)。
+
+### macOS / Linux
 
 ```bash
-# macOS / Linux
 curl -fsSL https://raw.githubusercontent.com/konghayao/peri/main/scripts/install.sh | bash
+```
 
-# Windows (PowerShell)
+### Windows (PowerShell)
+
+```powershell
 irm https://raw.githubusercontent.com/konghayao/peri/main/scripts/install.ps1 | iex
 ```
 
-## How We Built Peri with Nobody Coding
+---
 
-**Nobody Coding** means exactly what it sounds like. No human wrote a single line of Peri — not the architecture, not the TUI, not the harness tuning that makes open-source models reliable in a Agent loop. Humans decide *what*. AI figures out *how*. You're not pair programming — you're product managing an engineer that never sleeps. 99% of Peri was built this way.
+## 我们怎么用 Nobody Coding 造 Peri
 
-A typical pipeline:
+**Nobody Coding** 字面意思：没有人类写过一行 Peri 代码 — 架构、TUI、harness tuning 全是 AI 干的。人决定 *做什么*，AI 想 *怎么做*。你不是在结对编程，你是在管一个不睡觉的工程师。Peri 99% 的代码都是这么来的。
 
-| When you... | Pipeline kicks off |
-|---|---|
-| **Find a bug or piece of tech debt** | `issue-create` → `systematic-debugging` → `writing-plans` → `subagent-driven-development` → `issue-archive` → improve CLAUDE.md |
-| **Want to build a new feature** | `grill-me` → `writing-plans` → `subagent-driven-development` |
-| **Notice the codebase getting messy** | `slop-cleaner` → `improve-codebase-architecture` → `writing-plans` → `subagent-driven-development` |
-| **Need someone to grok the architecture** | `teacher` → assign a task → `teacher` |
+> 最近的 commit 几乎全是 DeepSeek 和 GLM 的产出。Claude 只在最初参与过。
 
-## Acknowledgments
+### 典型工作流
 
-- [Claude Code Best](https://github.com/claude-code-best/claude-code) — invaluable community support and feedback
-- [Superpowers](https://github.com/obra/superpowers) & [Matt Pocock's Skills](https://github.com/mattpocock/skills) — the skill suites that drive Peri's AI engineering workflow
-- [ACP](hhttps://agentclientprotocol.com/) — open protocol for agent-IDE communication
-- [rmcp](https://github.com/anthropics/rmcp) — Rust MCP client library
-- [Ratatui](https://ratatui.rs) & [Tokio](https://tokio.rs)
-- [Langfuse](https://langfuse.com) — LLM observability
-- [Zed](https://zed.dev) — first ACP-compatible IDE, proved the protocol works
+| 你要做的事 | 流水线 |
+|-----------|--------|
+| 发现 bug 或技术债 | `issue-create` → `systematic-debugging` → `writing-plans` → `subagent-driven-development` → `issue-archive` → 改进 CLAUDE.md |
+| 开新功能 | `grill-me` → `writing-plans` → `subagent-driven-development` |
+| 代码库变乱了 | `slop-cleaner` → `improve-codebase-architecture` → `writing-plans` → `subagent-driven-development` |
+| 需要理解架构 | `teacher` → 分配任务 → `teacher` |
 
-## License
+---
 
-Apache 2.0
+## 仓库结构
+
+```text
+peri/
+├── src/                       # Rust 源码
+│   ├── agent/                 # Agent loop 核心
+│   ├── tui/                   # 终端 UI (Ratatui)
+│   ├── tools/                 # 内置工具实现
+│   └── ...
+├── scripts/
+│   ├── install.sh             # macOS / Linux 安装器
+│   └── install.ps1            # Windows 安装器
+├── tests/
+├── README.md
+└── LICENSE                    # Apache 2.0
+```
+
+---
+
+## 致谢
+
+| 项目 | 说明 |
+|------|------|
+| [Claude Code Best](https://github.com/claude-code-best/claude-code) | 社区支持和反馈 |
+| [Superpowers](https://github.com/obra/superpowers) & [Matt Pocock's Skills](https://github.com/mattpocock/skills) | 驱动 Peri AI 工程工作流的 skill 套件 |
+| [ACP](https://agentclientprotocol.com/) | Agent-IDE 通信开放协议 |
+| [rmcp](https://github.com/anthropics/rmcp) | Rust MCP 客户端库 |
+| [Ratatui](https://ratatui.rs) & [Tokio](https://tokio.rs) | TUI 框架和异步运行时 |
+| [Langfuse](https://langfuse.com) | LLM 可观测性 |
+| [Zed](https://zed.dev) | 第一个 ACP 兼容 IDE，验证了协议可行性 |
+
+---
+
+## 许可证
+
+[Apache License 2.0](LICENSE) — 可自由使用、修改、分发，包括商业用途。

--- a/README_EN.md
+++ b/README_EN.md
@@ -1,0 +1,118 @@
+<div align="center">
+
+[中文](README.md) | **English**
+
+# Peri
+
+**Open-source models in an Agent Loop — a Rust terminal coding agent, fully compatible with the Claude Code ecosystem**
+
+Powered by DeepSeek-V4-Pro + GLM-5.1. Zero migration — your `.claude/` config just works. Even runs on RISC-V.
+
+[![GitHub stars](https://img.shields.io/github/stars/konghayao/peri?style=social)](https://github.com/konghayao/peri/stargazers)
+[![License](https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square)](LICENSE)
+
+[Why Peri](#why-peri) · [Features](#features) · [Install](#install) · [Nobody Coding](#how-we-built-peri-with-nobody-coding) · [Acknowledgments](#acknowledgments)
+
+</div>
+
+---
+
+## Why Peri?
+
+| | Other terminal agents | Peri |
+|---|---|---|
+| **Runtime** | Node.js / Bun, easily 1GB+ memory | Native Rust, fast startup, ~50MB memory |
+| **Model lock-in** | Tied to one LLM | Any: Anthropic, OpenAI-compatible, DeepSeek, GLM |
+| **Prompt caching** | Recomputes every round, wasting tokens | Frozen system prompt, 95-99% cache hit rate |
+| **Tool loading** | All tools in every request | Core tools resident, rest lazy-loaded via Tool Search |
+| **IDE integration** | Terminal only | ACP protocol — connects to Zed and other IDEs |
+| **Claude Code ecosystem** | Incompatible | Drop-in `.claude/` config, agents, skills, hooks, MCP |
+
+---
+
+## Features
+
+| Feature | Description |
+|---------|-------------|
+| **Native Rust** | Fast startup, low memory, zero runtime overhead |
+| **Context optimized** | Frozen system prompt + dynamic content isolation — no token waste |
+| **Multi-LLM** | Anthropic / OpenAI-compatible APIs — DeepSeek, GLM, whatever works for you |
+| **Claude Code compatible** | `.claude/` config, agents, skills, hooks, MCP, sub-agents — all reusable |
+| **Streaming Markdown** | Code blocks, tables, diffs — all rendered live |
+| **ACP protocol** | IDE-ready via [ACP](https://agentclientprotocol.com/) — Zed and more |
+| **Auto Compact** | Long sessions stay fast and cheap |
+| **Experimental** | Built-in LSP, split screen, background sub-agents |
+
+---
+
+## Install
+
+Binaries available for macOS (x86_64 / Apple Silicon), Linux (x86_64 / aarch64 / riscv64), and Windows (x86_64).
+
+### macOS / Linux
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/konghayao/peri/main/scripts/install.sh | bash
+```
+
+### Windows (PowerShell)
+
+```powershell
+irm https://raw.githubusercontent.com/konghayao/peri/main/scripts/install.ps1 | iex
+```
+
+---
+
+## How We Built Peri with Nobody Coding
+
+**Nobody Coding** means exactly what it sounds like. No human wrote a single line of Peri — not the architecture, not the TUI, not the harness tuning that makes open-source models reliable in an Agent loop. Humans decide *what*. AI figures out *how*. You're not pair programming — you're product managing an engineer that never sleeps. 99% of Peri was built this way.
+
+> Recent commits are almost entirely DeepSeek and GLM. Claude was just there in the beginning.
+
+### Typical Workflows
+
+| When you... | Pipeline kicks off |
+|---|---|
+| **Find a bug or tech debt** | `issue-create` → `systematic-debugging` → `writing-plans` → `subagent-driven-development` → `issue-archive` → improve CLAUDE.md |
+| **Want to build a new feature** | `grill-me` → `writing-plans` → `subagent-driven-development` |
+| **Notice the codebase getting messy** | `slop-cleaner` → `improve-codebase-architecture` → `writing-plans` → `subagent-driven-development` |
+| **Need someone to grok the architecture** | `teacher` → assign a task → `teacher` |
+
+---
+
+## Repository Structure
+
+```text
+peri/
+├── src/                       # Rust source code
+│   ├── agent/                 # Agent loop core
+│   ├── tui/                   # Terminal UI (Ratatui)
+│   ├── tools/                 # Built-in tool implementations
+│   └── ...
+├── scripts/
+│   ├── install.sh             # macOS / Linux installer
+│   └── install.ps1            # Windows installer
+├── tests/
+├── README.md
+└── LICENSE                    # Apache 2.0
+```
+
+---
+
+## Acknowledgments
+
+| Project | Description |
+|---------|-------------|
+| [Claude Code Best](https://github.com/claude-code-best/claude-code) | Community support and feedback |
+| [Superpowers](https://github.com/obra/superpowers) & [Matt Pocock's Skills](https://github.com/mattpocock/skills) | Skill suites driving Peri's AI engineering workflow |
+| [ACP](https://agentclientprotocol.com/) | Open protocol for agent-IDE communication |
+| [rmcp](https://github.com/anthropics/rmcp) | Rust MCP client library |
+| [Ratatui](https://ratatui.rs) & [Tokio](https://tokio.rs) | TUI framework and async runtime |
+| [Langfuse](https://langfuse.com) | LLM observability |
+| [Zed](https://zed.dev) | First ACP-compatible IDE, proved the protocol works |
+
+---
+
+## License
+
+[Apache License 2.0](LICENSE) — free to use, modify, and distribute, including commercial use.


### PR DESCRIPTION
## Summary
- 按 cc-hooks README 风格重写 peri README
- 新增中英文双版本（README.md 中文默认，README_EN.md 英文）

## 改动内容
- 居中 header + badges + 导航链接
- 对比表格（为什么选 Peri）
- 核心能力表格
- 安装命令（macOS/Linux/Windows）
- Nobody Coding 工作流表格
- 仓库结构树形图
- 致谢表格

🤖 Generated with [Claude Code](https://claude.com/claude-code)