### PR TITLE
feat(agm): add Agent Package Manager CLI tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -187,4 +187,4 @@ vendor/
 node_modules
 dist
 settings.json
-.claude/worktrees/
+.claude/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "peri-widgets",
     "peri-lsp",
     "side-projects/git-graph",
+    "agm",
 ]
 resolver = "2"
 
@@ -80,3 +81,7 @@ libmimalloc-sys = { version = "0.1", features = ["extended"] }
 tikv-jemallocator = "0.6"
 tikv-jemalloc-ctl = { version = "0.6", features = ["stats", "use_std"] }
 tikv-jemalloc-sys = "0.6"
+
+clap = { version = "4", features = ["derive"] }
+semver = "1"
+sha2 = "0.10"

--- a/agm/Cargo.toml
+++ b/agm/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "agm"
+version.workspace = true
+edition.workspace = true
+
+[[bin]]
+name = "agm"
+path = "src/main.rs"
+
+[dependencies]
+tokio.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+reqwest.workspace = true
+tempfile.workspace = true
+thiserror.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
+dirs-next.workspace = true
+clap.workspace = true
+semver.workspace = true
+sha2.workspace = true
+flate2 = "1"
+tar = "0.4"

--- a/agm/install.ps1
+++ b/agm/install.ps1
@@ -1,0 +1,270 @@
+# AGM Installer for Windows
+# Usage: irm https://raw.githubusercontent.com/konghayao/peri/main/agm/install.ps1 | iex
+#
+# Options:
+#   $env:AGM_INSTALL_VERSION  Specific version tag (e.g. agm-v0.1.0), empty = latest
+#   $env:AGM_INSTALL_DIR      Install directory (default: $env:USERPROFILE\.agm)
+#   $env:GITHUB_PROXY         GitHub download proxy prefix (replaces https://github.com)
+#   $env:GITHUB_TOKEN         GitHub personal access token (bypasses API rate limiting)
+#   $env:AGM_NO_PATH_HINT     Set to 1 to skip PATH hint
+#   $env:AGM_INSTALL_PLATFORM Override platform detection (e.g. windows-x86_64)
+#
+# Example:
+#   $env:AGM_INSTALL_VERSION="agm-v0.1.0"; irm ... | iex
+#   $env:GITHUB_PROXY="https://ghproxy.com/https://github.com"; irm ... | iex
+
+$ErrorActionPreference = "Stop"
+$ProgressPreference = "SilentlyContinue"
+
+# --- Logging ---
+function info  { Write-Host "[INFO]  $args" -ForegroundColor Green }
+function warn  { Write-Host "[WARN]  $args" -ForegroundColor Yellow }
+function error { Write-Host "[ERROR] $args" -ForegroundColor Red }
+function step  { Write-Host "[STEP]  $args" -ForegroundColor Cyan }
+
+# --- Platform Detection ---
+function Detect-Platform {
+    if ($env:AGM_INSTALL_PLATFORM) {
+        if ($env:AGM_INSTALL_PLATFORM -notmatch '^(macos|linux|windows)-(x86_64|aarch64|riscv64)$') {
+            error "Invalid AGM_INSTALL_PLATFORM: $env:AGM_INSTALL_PLATFORM"
+            Write-Host "  Expected: macos-x86_64 | macos-aarch64 | linux-x86_64 | linux-aarch64 | linux-riscv64 | windows-x86_64"
+            exit 1
+        }
+        info "Platform (manual): $env:AGM_INSTALL_PLATFORM"
+        return $env:AGM_INSTALL_PLATFORM
+    }
+
+    $arch = switch ($env:PROCESSOR_ARCHITECTURE) {
+        "AMD64" { "x86_64" }
+        "ARM64" { "aarch64" }
+        default {
+            error "Unsupported architecture: $env:PROCESSOR_ARCHITECTURE"
+            exit 1
+        }
+    }
+
+    $platform = "windows-${arch}"
+    info "Detected platform: $platform"
+    return $platform
+}
+
+# --- Download with optional proxy ---
+function Get-DownloadUrl {
+    param([string]$Url)
+    if ($env:GITHUB_PROXY) {
+        return $Url -replace 'https://github\.com', $env:GITHUB_PROXY
+    }
+    return $Url
+}
+
+# --- GitHub API request (with optional token) ---
+function Invoke-GitHubApi {
+    param([string]$Url)
+    $headers = @{}
+    if ($env:GITHUB_TOKEN) {
+        $headers["Authorization"] = "Bearer $env:GITHUB_TOKEN"
+    }
+    $response = Invoke-RestMethod -Uri $Url -Headers $headers -ErrorAction SilentlyContinue
+    return $response
+}
+
+# --- Cleanup Old Versions ---
+function Clean-OldVersions {
+    param([string]$InstallDir, [string]$CurrentVersion)
+
+    $oldDirs = @(Get-ChildItem -Path $InstallDir -Directory | Where-Object {
+        $_.Name -match '^agm-v' -and $_.Name -ne $CurrentVersion
+    })
+
+    if ($oldDirs.Count -eq 0) {
+        info "No old versions to clean up."
+        return
+    }
+
+    Write-Host ""
+    warn "Found $($oldDirs.Count) old version(s):"
+    $totalSize = 0
+    foreach ($d in $oldDirs) {
+        $size = (Get-ChildItem -Path $d.FullName -Recurse -File -ErrorAction SilentlyContinue |
+                 Measure-Object -Property Length -Sum).Sum
+        if (-not $size) { $size = 0 }
+        $totalSize += $size
+        $sizeMB = [math]::Round($size / 1MB, 1)
+        Write-Host "  $($d.Name)  ($sizeMB MB)"
+    }
+    $totalMB = [math]::Round($totalSize / 1MB, 1)
+    Write-Host "  Total: $totalMB MB"
+    Write-Host ""
+
+    $answer = Read-Host "Delete old versions? [y/N]"
+    switch ($answer) {
+        { $_ -match '^[yY](es)?$' } {
+            foreach ($d in $oldDirs) {
+                Remove-Item -Recurse -Force $d.FullName
+                info "Removed: $($d.Name)"
+            }
+            info "Cleaned up $($oldDirs.Count) old version(s)."
+        }
+        default {
+            info "Skipped cleanup."
+        }
+    }
+}
+
+# --- Main ---
+function Main {
+    $InstallDir = if ($env:AGM_INSTALL_DIR) { $env:AGM_INSTALL_DIR } else { Join-Path $env:USERPROFILE ".agm" }
+    $GitHubApi = "https://api.github.com/repos/konghayao/peri"
+
+    Write-Host ""
+    info "AGM Installer (Windows)"
+    info "-------------------------------"
+
+    $Platform = Detect-Platform
+    $AssetName = "agm-${Platform}.zip"
+    $ExeName = "agm.exe"
+
+    # Fetch release info
+    if ($env:AGM_INSTALL_VERSION) {
+        $VersionTag = $env:AGM_INSTALL_VERSION
+        step "Fetching release: $VersionTag..."
+        try {
+            $Release = Invoke-GitHubApi "$GitHubApi/releases/tags/$VersionTag"
+        } catch {
+            error "Failed to fetch release '$VersionTag'. Does this tag exist?"
+            exit 1
+        }
+    } else {
+        step "Fetching latest AGM release..."
+        try {
+            $Releases = Invoke-GitHubApi "$GitHubApi/releases?per_page=30"
+        } catch {
+            error "Failed to fetch releases from GitHub."
+            exit 1
+        }
+
+        $VersionTag = ($Releases | Where-Object { $_.tag_name -like "agm-*" } | Select-Object -First 1).tag_name
+        if (-not $VersionTag) {
+            error "No AGM release found."
+            exit 1
+        }
+
+        try {
+            $Release = Invoke-GitHubApi "$GitHubApi/releases/tags/$VersionTag"
+        } catch {
+            error "Failed to fetch release '$VersionTag'."
+            exit 1
+        }
+    }
+
+    info "Found release: $VersionTag"
+
+    # Create install directory
+    $VersionDir = Join-Path $InstallDir $VersionTag
+    $TargetExe = Join-Path $VersionDir $ExeName
+
+    # Check if already installed
+    if (Test-Path $TargetExe) {
+        if ($env:AGM_FORCE -ne "1") {
+            info "Already up to date ($VersionTag). Use AGM_FORCE=1 to reinstall."
+            Clean-OldVersions -InstallDir $InstallDir -CurrentVersion $VersionTag
+            exit 0
+        }
+        info "Force reinstall, removing existing..."
+        Remove-Item -Recurse -Force $VersionDir -ErrorAction SilentlyContinue
+    }
+
+    # Find matching asset
+    $Asset = $Release.assets | Where-Object { $_.name -eq $AssetName }
+    if (-not $Asset) {
+        error "No binary found for platform '$Platform'."
+        Write-Host ""
+        Write-Host "Available assets:"
+        $Release.assets | ForEach-Object { Write-Host "  - $($_.name)" }
+        exit 1
+    }
+
+    $DownloadUrl = $Asset.browser_download_url
+    info "Binary: $AssetName"
+
+    New-Item -ItemType Directory -Force -Path $VersionDir | Out-Null
+
+    $ZipPath = Join-Path $VersionDir $AssetName
+
+    # Download
+    $FinalUrl = Get-DownloadUrl $DownloadUrl
+    if ($FinalUrl -ne $DownloadUrl) {
+        info "Using proxy: $FinalUrl"
+    }
+
+    step "Downloading..."
+    try {
+        Invoke-WebRequest -Uri $FinalUrl -OutFile $ZipPath
+    } catch {
+        error "Download failed: $_"
+        exit 1
+    }
+
+    # Extract
+    step "Extracting..."
+    try {
+        Expand-Archive -Path $ZipPath -DestinationPath $VersionDir -Force
+    } catch {
+        error "Extraction failed: $_"
+        exit 1
+    }
+    Remove-Item -Force $ZipPath -ErrorAction SilentlyContinue
+
+    # Zip contains agm-<platform>.exe, find and rename to agm.exe
+    $SourceExe = Get-ChildItem -Path $VersionDir -Recurse -Filter "*.exe" | Where-Object { $_.Name -notlike "unins*" } | Select-Object -First 1
+    if (-not $SourceExe) {
+        error "No .exe found in extracted archive."
+        Get-ChildItem -Path $VersionDir -Recurse | ForEach-Object { Write-Host "  $($_.FullName)" }
+        exit 1
+    }
+
+    if ($SourceExe.FullName -ne $TargetExe) {
+        Move-Item -Force $SourceExe.FullName $TargetExe
+    }
+
+    info "Installed to: $TargetExe"
+
+    # Create convenience copy
+    $LinkPath = Join-Path $InstallDir $ExeName
+    Copy-Item -Force $TargetExe $LinkPath
+
+    # Write current version
+    $VersionFile = Join-Path $InstallDir "current-version.txt"
+    $VersionTag | Out-File -FilePath $VersionFile -Encoding ascii -NoNewline
+
+    # --- PATH Setup ---
+    if ($env:AGM_NO_PATH_HINT -ne "1") {
+        $currentPath = [Environment]::GetEnvironmentVariable("Path", "User") -split ";"
+        $installPathNormalized = (Resolve-Path $InstallDir).Path.TrimEnd("\")
+
+        $alreadyInPath = $false
+        foreach ($p in $currentPath) {
+            if ($p.TrimEnd("\") -eq $installPathNormalized) {
+                $alreadyInPath = $true
+                break
+            }
+        }
+
+        if (-not $alreadyInPath) {
+            [Environment]::SetEnvironmentVariable("Path", "$InstallDir;$([Environment]::GetEnvironmentVariable('Path', 'User'))", "User")
+            info "Added $InstallDir to user PATH"
+            $env:Path = "$InstallDir;$env:Path"
+        }
+    }
+
+    # Offer to clean up old versions
+    Clean-OldVersions -InstallDir $InstallDir -CurrentVersion $VersionTag
+
+    Write-Host ""
+    info "Installation complete! Version: $VersionTag"
+    Write-Host ""
+    info "Open a new terminal and run 'agm' to start."
+    Write-Host ""
+}
+
+Main

--- a/agm/install.sh
+++ b/agm/install.sh
@@ -1,0 +1,299 @@
+#!/bin/bash
+set -euo pipefail
+export LC_ALL=C
+
+# AGM Install Script
+# Usage: curl -fsSL https://raw.githubusercontent.com/konghayao/peri/main/agm/install.sh | bash
+#
+# Options:
+#   AGM_INSTALL_VERSION  Specific version tag (e.g. agm-v0.1.0), empty = latest
+#   AGM_INSTALL_DIR      Install directory (default: $HOME/.agm)
+#   GITHUB_PROXY         GitHub download proxy prefix (replaces https://github.com in download URL)
+#   GITHUB_TOKEN         GitHub personal access token (bypasses API rate limiting)
+#   AGM_NO_PATH_HINT     Set to 1 to skip PATH hint
+#   AGM_INSTALL_PLATFORM Override platform detection (e.g. linux-x86_64, macos-aarch64)
+#
+# Example:
+#   AGM_INSTALL_VERSION=agm-v0.1.0 bash install-agm.sh
+#   GITHUB_PROXY=https://ghproxy.com/https://github.com curl ... | bash
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+info()    { echo -e "${GREEN}[INFO]${NC}  $*"; }
+warn()    { echo -e "${YELLOW}[WARN]${NC}  $*"; }
+error()   { echo -e "${RED}[ERROR]${NC} $*" >&2; }
+step()    { echo -e "${CYAN}[STEP]${NC}  $*"; }
+
+# --- Platform Detection ---
+detect_platform() {
+    local os arch platform
+
+    if [[ -n "${AGM_INSTALL_PLATFORM:-}" ]]; then
+        if [[ ! "${AGM_INSTALL_PLATFORM}" =~ ^(macos|linux|windows)-(x86_64|aarch64|riscv64)$ ]]; then
+            error "Invalid AGM_INSTALL_PLATFORM: ${AGM_INSTALL_PLATFORM}"
+            echo "  Expected: macos-x86_64 | macos-aarch64 | linux-x86_64 | linux-aarch64 | linux-riscv64 | windows-x86_64"
+            exit 1
+        fi
+        info "Platform (manual): ${AGM_INSTALL_PLATFORM}" >&2
+        echo "${AGM_INSTALL_PLATFORM}"
+        return
+    fi
+
+    case "$(uname -s)" in
+        Darwin)  os="macos" ;;
+        Linux)   os="linux" ;;
+        *)       error "Unsupported OS: $(uname -s)"; exit 1 ;;
+    esac
+
+    case "$(uname -m)" in
+        x86_64|amd64)  arch="x86_64" ;;
+        aarch64|arm64) arch="aarch64" ;;
+        riscv64)       arch="riscv64" ;;
+        *)             error "Unsupported arch: $(uname -m)"; exit 1 ;;
+    esac
+
+    platform="${os}-${arch}"
+    info "Detected platform: ${platform}" >&2
+    echo "${platform}"
+}
+
+# --- Download with optional proxy ---
+get_download_url() {
+    local url="$1"
+    local proxy="${GITHUB_PROXY:-}"
+    if [[ -n "${proxy}" ]]; then
+        echo "${url/https:\/\/github.com/${proxy}}"
+    else
+        echo "${url}"
+    fi
+}
+
+# --- GitHub API request (with optional token) ---
+github_api() {
+    local url="$1"
+    local auth_header=""
+    if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+        auth_header="-H Authorization: Bearer ${GITHUB_TOKEN}"
+    fi
+    curl -fsSL ${auth_header:-} "${url}" 2>/dev/null
+}
+
+# --- Cleanup Old Versions ---
+cleanup_old_versions() {
+    local install_dir="$1"
+    local current_version="$2"
+
+    local old_dirs=()
+    for d in "${install_dir}"/agm-v*; do
+        [[ -d "$d" ]] || continue
+        local base
+        base=$(basename "$d")
+        [[ "$base" == "$current_version" ]] && continue
+        old_dirs+=("$d")
+    done
+
+    if [[ ${#old_dirs[@]} -eq 0 ]]; then
+        info "No old versions to clean up."
+        return
+    fi
+
+    echo ""
+    warn "Found ${#old_dirs[@]} old version(s):"
+    for d in "${old_dirs[@]}"; do
+        local size
+        size=$(du -sh "$d" 2>/dev/null | cut -f1)
+        echo "  $(basename "$d")  (${size})"
+    done
+    local total_human
+    total_human=$(du -sh "${old_dirs[@]}" 2>/dev/null | tail -1 | cut -f1)
+    echo "  Total: ${total_human}"
+    echo ""
+
+    if ! [[ -t 0 ]] && [[ -e /dev/tty ]]; then
+        exec 3< /dev/tty
+    else
+        exec 3<&0
+    fi
+
+    echo -e "${YELLOW}[WARN]${NC}  Delete old versions? [y/N] " >&2
+    local answer
+    read -r answer <&3
+    exec 3<&-
+
+    case "${answer}" in
+        [yY]|[yY][eE][sS])
+            for d in "${old_dirs[@]}"; do
+                rm -rf "$d"
+                info "Removed: $(basename "$d")"
+            done
+            info "Cleaned up ${#old_dirs[@]} old version(s)."
+            ;;
+        *)
+            info "Skipped cleanup."
+            ;;
+    esac
+}
+
+# --- Main ---
+main() {
+    INSTALL_DIR="${AGM_INSTALL_DIR:-${HOME}/.agm}"
+    GITHUB_API="https://api.github.com/repos/konghayao/peri"
+
+    echo ""
+    info "AGM Installer"
+    info "-------------------------------"
+
+    PLATFORM=$(detect_platform)
+    ASSET_NAME="agm-${PLATFORM}.tar.gz"
+
+    # Fetch release info
+    if [[ -n "${AGM_INSTALL_VERSION:-}" ]]; then
+        VERSION_TAG="${AGM_INSTALL_VERSION}"
+        step "Fetching release: ${VERSION_TAG}..."
+        RELEASE_JSON=$(github_api "${GITHUB_API}/releases/tags/${VERSION_TAG}") || {
+            error "Failed to fetch release '${VERSION_TAG}'. Does this tag exist?"
+            exit 1
+        }
+    else
+        step "Fetching latest AGM release..."
+        RELEASES_JSON=$(github_api "${GITHUB_API}/releases?per_page=30") || {
+            error "Failed to fetch releases from GitHub."
+            exit 1
+        }
+        VERSION_TAG=$(echo "${RELEASES_JSON}" | tr ',' '\n' | grep -F '"tag_name"' | grep -F '"agm-' | head -1 | cut -d'"' -f4)
+        if [[ -z "${VERSION_TAG}" ]]; then
+            error "No AGM release found."
+            exit 1
+        fi
+
+        RELEASE_JSON=$(github_api "${GITHUB_API}/releases/tags/${VERSION_TAG}") || {
+            error "Failed to fetch release '${VERSION_TAG}'."
+            exit 1
+        }
+    fi
+
+    info "Found release: ${VERSION_TAG}"
+
+    # Create install directory
+    VERSION_DIR="${INSTALL_DIR}/${VERSION_TAG}"
+    TARGET="${VERSION_DIR}/agm"
+
+    # Check if already installed
+    if [[ -f "${TARGET}" ]]; then
+        if [[ "${AGM_FORCE:-}" != "1" ]]; then
+            info "Already up to date (${VERSION_TAG}). Use AGM_FORCE=1 to reinstall."
+            cleanup_old_versions "${INSTALL_DIR}" "${VERSION_TAG}"
+            exit 0
+        fi
+        info "Force reinstall, removing existing..."
+        rm -rf "${VERSION_DIR}"
+    fi
+
+    # Find matching asset
+    ASSET_DOWNLOAD_URL=$(echo "${RELEASE_JSON}" | tr ',' '\n' | grep -F '"browser_download_url"' | grep -F "${ASSET_NAME}" | head -1 | cut -d'"' -f4)
+
+    if [[ -z "${ASSET_DOWNLOAD_URL}" ]]; then
+        error "No binary found for platform '${PLATFORM}'."
+        echo ""
+        echo "Available assets:"
+        echo "${RELEASE_JSON}" | tr ',' '\n' | grep -F '"browser_download_url"' | cut -d'"' -f4 | sed 's/^/  - /'
+        exit 1
+    fi
+
+    info "Binary: ${ASSET_NAME}"
+
+    mkdir -p "${VERSION_DIR}"
+
+    TARBALL="${VERSION_DIR}/${ASSET_NAME}"
+
+    # Download tarball
+    FINAL_URL=$(get_download_url "${ASSET_DOWNLOAD_URL}")
+    if [[ "${FINAL_URL}" != "${ASSET_DOWNLOAD_URL}" ]]; then
+        info "Using proxy: ${FINAL_URL}"
+    fi
+
+    step "Downloading..."
+    curl -fSL --progress-bar "${FINAL_URL}" -o "${TARBALL}" || {
+        error "Download failed."
+        exit 1
+    }
+
+    # Extract tarball
+    step "Extracting..."
+    tar -xzf "${TARBALL}" -C "${VERSION_DIR}" || {
+        error "Extraction failed."
+        exit 1
+    }
+    rm -f "${TARBALL}"
+
+    # Tarball contains agm-<platform>, rename to agm
+    if [[ ! -f "${TARGET}" ]]; then
+        EXTRACTED=$(ls "${VERSION_DIR}"/agm-* 2>/dev/null | head -1)
+        if [[ -f "${EXTRACTED}" ]]; then
+            mv "${EXTRACTED}" "${TARGET}"
+        else
+            error "No binary found in extracted tarball."
+            ls -la "${VERSION_DIR}" || true
+            exit 1
+        fi
+    fi
+
+    chmod +x "${TARGET}"
+    info "Installed to: ${TARGET}"
+
+    # Create symlink for convenience
+    LINK="${INSTALL_DIR}/agm"
+    rm -f "${LINK}"
+    ln -sf "${TARGET}" "${LINK}"
+
+    # Write current version
+    echo "${VERSION_TAG}" > "${INSTALL_DIR}/current-version.txt"
+
+    # --- PATH Setup ---
+    if [[ "${AGM_NO_PATH_HINT:-}" != "1" ]]; then
+        BIN_LINK="${INSTALL_DIR}/agm"
+        SHELL_PROFILE=""
+        case "${SHELL:-}" in
+            */zsh)  SHELL_PROFILE="${HOME}/.zshrc" ;;
+            */bash) SHELL_PROFILE="${HOME}/.bashrc" ;;
+            */fish) SHELL_PROFILE="${HOME}/.config/fish/config.fish" ;;
+        esac
+
+        if [[ -n "${SHELL_PROFILE}" ]]; then
+            INSTALL_DIR_ESC="${INSTALL_DIR//\./\\.}"
+            if ! grep -qE "(^|[:\" ])${INSTALL_DIR_ESC}([:\"\$ ]|$)" "${SHELL_PROFILE}" 2>/dev/null; then
+                if [[ "${SHELL}" == */fish ]]; then
+                    echo "set -gx PATH ${INSTALL_DIR} \$PATH" >> "${SHELL_PROFILE}"
+                else
+                    echo "export PATH=\"${INSTALL_DIR}:\$PATH\"" >> "${SHELL_PROFILE}"
+                fi
+                info "Added ${INSTALL_DIR} to PATH in ${SHELL_PROFILE}"
+            fi
+        else
+            echo ""
+            warn "Unknown shell. Add this directory to your PATH manually:"
+            echo "    export PATH=\"${INSTALL_DIR}:\$PATH\""
+            echo ""
+        fi
+    fi
+
+    # Offer to clean up old versions
+    cleanup_old_versions "${INSTALL_DIR}" "${VERSION_TAG}"
+
+    echo ""
+    info "Installation complete! Version: ${VERSION_TAG}"
+    echo ""
+
+    if command -v "${BIN_LINK}" &>/dev/null || [[ -x "${BIN_LINK}" ]]; then
+        info "Run 'agm' to start."
+    else
+        info "Run: ${BIN_LINK}"
+    fi
+    echo ""
+}
+
+main

--- a/agm/src/adapter.rs
+++ b/agm/src/adapter.rs
@@ -1,0 +1,133 @@
+use crate::error::Result;
+use crate::resolver::PackageType;
+use std::path::{Path, PathBuf};
+
+/// 工具适配器 trait
+pub trait ToolAdapter: Send + Sync {
+    /// 工具标识名
+    fn target_name(&self) -> &str;
+
+    /// 类型到目标目录的映射
+    fn map_dir(&self, typ: PackageType, project_root: &Path) -> PathBuf {
+        let subdir = match typ {
+            PackageType::Skills => "skills",
+            PackageType::Agents => "agents",
+            PackageType::Mcp => "mcp",
+        };
+        let dot_dir = format!(".{}", self.target_name());
+        project_root.join(dot_dir).join(subdir)
+    }
+
+    /// 安装：从 store 建 symlink 到工具目录
+    fn install(&self, store_path: &Path, target_dir: &Path, pkg_name: &str) -> Result<()> {
+        std::fs::create_dir_all(target_dir)?;
+
+        let link_path = target_dir.join(pkg_name);
+
+        if link_path.exists() {
+            if let Ok(meta) = std::fs::symlink_metadata(&link_path) {
+                if meta.file_type().is_symlink() {
+                    let existing = std::fs::read_link(&link_path)?;
+                    if existing == store_path {
+                        return Ok(());
+                    }
+                }
+            }
+        }
+
+        if link_path.exists() {
+            if link_path.is_symlink() || link_path.is_file() {
+                std::fs::remove_file(&link_path)?;
+            } else if link_path.is_dir() {
+                std::fs::remove_dir_all(&link_path)?;
+            }
+        }
+
+        #[cfg(unix)]
+        {
+            std::os::unix::fs::symlink(store_path, &link_path)?;
+        }
+        #[cfg(windows)]
+        {
+            if store_path.is_dir() {
+                std::os::windows::fs::symlink_dir(store_path, &link_path)?;
+            } else {
+                std::os::windows::fs::symlink_file(store_path, &link_path)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// 安装后的收尾钩子
+    fn post_install(&self) -> Result<()> {
+        Ok(())
+    }
+
+    /// 卸载：删除 symlink
+    fn uninstall(&self, target_dir: &Path, pkg_name: &str) -> Result<()> {
+        let link_path = target_dir.join(pkg_name);
+        if link_path.exists() {
+            if link_path.is_symlink() {
+                std::fs::remove_file(&link_path)?;
+            } else if link_path.is_dir() {
+                std::fs::remove_dir_all(&link_path)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+// ---- 内置适配器 ----
+
+pub struct ClaudeAdapter;
+impl ToolAdapter for ClaudeAdapter {
+    fn target_name(&self) -> &str {
+        "claude"
+    }
+}
+
+pub struct CodexAdapter;
+impl ToolAdapter for CodexAdapter {
+    fn target_name(&self) -> &str {
+        "codex"
+    }
+}
+
+pub struct CopilotAdapter;
+impl ToolAdapter for CopilotAdapter {
+    fn target_name(&self) -> &str {
+        "copilot"
+    }
+}
+
+/// 根据名称获取适配器
+pub fn get_adapter(name: &str) -> Option<Box<dyn ToolAdapter>> {
+    match name.to_lowercase().as_str() {
+        "claude" => Some(Box::new(ClaudeAdapter)),
+        "codex" => Some(Box::new(CodexAdapter)),
+        "copilot" => Some(Box::new(CopilotAdapter)),
+        _ => None,
+    }
+}
+
+/// 列出所有内置适配器名称
+pub fn list_adapters() -> Vec<&'static str> {
+    vec!["claude", "codex", "copilot"]
+}
+
+/// 适配器名称到 symlink 名称的映射（冲突时添加 scope 前缀）
+pub fn symlink_name(pkg_name: &str, existing_names: &[String]) -> String {
+    let base = pkg_name.replace('/', "_").replace('@', "");
+    if existing_names.contains(&base) {
+        let parts: Vec<&str> = pkg_name.split('/').collect();
+        if parts.len() >= 2 {
+            let prefix = parts[0].trim_start_matches('@');
+            format!("{}_{}", prefix, parts.last().unwrap())
+        } else {
+            base
+        }
+    } else {
+        base
+    }
+}

--- a/agm/src/commands/gc.rs
+++ b/agm/src/commands/gc.rs
@@ -1,0 +1,28 @@
+use crate::config::AgmConfig;
+use crate::error::Result;
+use crate::store::Store;
+
+pub fn execute() -> Result<()> {
+    let config = AgmConfig::load()?;
+    let store = Store::new(config.store_path.clone());
+
+    if !config.store_path.exists() {
+        println!("Store is empty.");
+        return Ok(());
+    }
+
+    let packages = store.list_packages()?;
+    if packages.is_empty() {
+        println!("Store is empty.");
+        return Ok(());
+    }
+
+    println!(
+        "Store contains {} package(s) at {}",
+        packages.len(),
+        config.store_path.display()
+    );
+    println!("GC: scanning for unreferenced packages... (v1: manual review recommended)");
+    println!("Done. {} package(s) in store.", packages.len());
+    Ok(())
+}

--- a/agm/src/commands/init.rs
+++ b/agm/src/commands/init.rs
@@ -1,0 +1,37 @@
+use crate::error::Result;
+use crate::types::ProjectManifest;
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+pub fn execute(project_dir: Option<PathBuf>) -> Result<()> {
+    let dir = project_dir.unwrap_or_else(|| PathBuf::from("."));
+    let manifest_path = dir.join("agm.json");
+
+    if manifest_path.exists() {
+        println!("agm.json already exists in {}", dir.display());
+        return Ok(());
+    }
+
+    let name = dir
+        .canonicalize()
+        .ok()
+        .and_then(|p| p.file_name().map(|n| n.to_string_lossy().to_string()))
+        .unwrap_or_else(|| "my-agent-project".into());
+
+    let manifest = ProjectManifest {
+        name,
+        version: "1.0.0".into(),
+        description: String::new(),
+        author: String::new(),
+        registry: None,
+        targets: vec!["claude".into()],
+        skills: BTreeMap::new(),
+        agents: BTreeMap::new(),
+        mcp: BTreeMap::new(),
+        overrides: BTreeMap::new(),
+    };
+
+    manifest.save(&manifest_path)?;
+    println!("Created {}", manifest_path.display());
+    Ok(())
+}

--- a/agm/src/commands/install.rs
+++ b/agm/src/commands/install.rs
@@ -1,0 +1,60 @@
+use crate::config::AgmConfig;
+use crate::error::{AgmError, Result};
+use crate::installer::InstallContext;
+use crate::types::ProjectManifest;
+use std::path::PathBuf;
+
+pub fn execute(target: &str, git_url: Option<&str>, project_dir: Option<PathBuf>) -> Result<()> {
+    let dir = project_dir.unwrap_or_else(|| PathBuf::from("."));
+    let manifest_path = dir.join("agm.json");
+
+    // --git 模式：直接安装 URL，没有 agm.json 则自动创建
+    if let Some(url) = git_url {
+        let manifest = if manifest_path.exists() {
+            ProjectManifest::load(&manifest_path)?
+        } else {
+            let name = dir
+                .canonicalize()
+                .ok()
+                .and_then(|p| p.file_name().map(|n| n.to_string_lossy().to_string()))
+                .unwrap_or_else(|| "my-agent-project".into());
+            ProjectManifest {
+                name,
+                version: "1.0.0".into(),
+                description: String::new(),
+                author: String::new(),
+                registry: None,
+                targets: vec![target.to_string()],
+                skills: std::collections::BTreeMap::new(),
+                agents: std::collections::BTreeMap::new(),
+                mcp: std::collections::BTreeMap::new(),
+                overrides: std::collections::BTreeMap::new(),
+            }
+        };
+
+        let config = AgmConfig::load()?;
+        println!("Installing from {} to {}...", url, target);
+        let mut ctx = InstallContext::new(config, manifest, target, dir)?;
+        ctx.install_from_git(url)?;
+        println!("Done.");
+        return Ok(());
+    }
+
+    // 普通模式：从 agm.json 安装
+    if !manifest_path.exists() {
+        return Err(AgmError::ManifestNotFound);
+    }
+
+    let manifest = ProjectManifest::load(&manifest_path)?;
+    let config = AgmConfig::load()?;
+
+    println!("Installing to {}...", target);
+    let mut ctx = InstallContext::new(config, manifest, target, dir)?;
+    ctx.install_all()?;
+
+    println!(
+        "Done. Installed to .{}/skills/, .{}/agents/, .{}/mcp/",
+        target, target, target
+    );
+    Ok(())
+}

--- a/agm/src/commands/list.rs
+++ b/agm/src/commands/list.rs
@@ -1,0 +1,65 @@
+use crate::error::{AgmError, Result};
+use crate::resolver::is_git_dep;
+use crate::types::*;
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+pub fn execute(project_dir: Option<PathBuf>) -> Result<()> {
+    let dir = project_dir.unwrap_or_else(|| PathBuf::from("."));
+    let manifest_path = dir.join("agm.json");
+
+    if !manifest_path.exists() {
+        return Err(AgmError::ManifestNotFound);
+    }
+
+    let manifest = ProjectManifest::load(&manifest_path)?;
+    let lock_path = dir.join("agm.lock.json");
+    let lock = if lock_path.exists() {
+        Some(LockFile::load(&lock_path)?)
+    } else {
+        None
+    };
+
+    println!("Dependencies for {}:\n", manifest.name);
+
+    print_section("skills", &manifest.skills, &lock);
+    print_section("agents", &manifest.agents, &lock);
+    print_section("mcp", &manifest.mcp, &lock);
+
+    if !manifest.overrides.is_empty() {
+        println!("Overrides:");
+        for (name, version) in &manifest.overrides {
+            println!("  {} → {}", name, version);
+        }
+    }
+
+    Ok(())
+}
+
+fn print_section(label: &str, deps: &BTreeMap<String, String>, lock: &Option<LockFile>) {
+    if deps.is_empty() {
+        return;
+    }
+    println!("[{}]", label);
+    for (name, version) in deps {
+        let source = if is_git_dep(name) { "git" } else { "registry" };
+        let installed = lock.as_ref().and_then(|l| {
+            l.packages
+                .iter()
+                .find(|(k, _)| k.starts_with(name))
+                .map(|(_, p)| p.targets.join(", "))
+        });
+
+        match installed {
+            Some(targets) if !targets.is_empty() => {
+                println!(
+                    "  ✓ {} {} ({}) [installed: {}]",
+                    name, version, source, targets
+                );
+            }
+            _ => {
+                println!("  ✗ {} {} ({}) [pending]", name, version, source);
+            }
+        }
+    }
+}

--- a/agm/src/commands/mod.rs
+++ b/agm/src/commands/mod.rs
@@ -1,0 +1,8 @@
+pub mod gc;
+pub mod init;
+pub mod install;
+pub mod list;
+pub mod publish;
+pub mod self_update;
+pub mod uninstall;
+pub mod update;

--- a/agm/src/commands/publish.rs
+++ b/agm/src/commands/publish.rs
@@ -1,0 +1,22 @@
+use crate::error::{AgmError, Result};
+use crate::types::PackageManifest;
+use std::path::PathBuf;
+
+pub fn execute(registry_url: Option<String>, project_dir: Option<PathBuf>) -> Result<()> {
+    let dir = project_dir.unwrap_or_else(|| PathBuf::from("."));
+    let manifest_path = dir.join("agm.package.json");
+    if !manifest_path.exists() {
+        return Err(AgmError::Other(
+            "agm.package.json not found. Are you in a package directory?".into(),
+        ));
+    }
+
+    let pkg = PackageManifest::load(&manifest_path)?;
+    println!("Publishing {}@{}...", pkg.name, pkg.version);
+    println!("  skills:  {:?}", pkg.skills);
+    println!("  agents:  {:?}", pkg.agents);
+    println!("  mcp:     {:?}", pkg.mcp);
+    let _ = registry_url;
+    println!("Done (dry run — registry upload not implemented in v1)");
+    Ok(())
+}

--- a/agm/src/commands/self_update.rs
+++ b/agm/src/commands/self_update.rs
@@ -1,0 +1,39 @@
+use crate::error::{AgmError, Result};
+use std::process::Command;
+
+const INSTALL_SH_URL: &str = "https://raw.githubusercontent.com/konghayao/peri/main/agm/install.sh";
+const INSTALL_PS1_URL: &str =
+    "https://raw.githubusercontent.com/konghayao/peri/main/agm/install.ps1";
+
+pub fn execute(force: bool) -> Result<()> {
+    if cfg!(windows) {
+        let env_setup = if force { "$env:AGM_FORCE='1'; " } else { "" };
+        let script = format!("{}irm {} | iex", env_setup, INSTALL_PS1_URL);
+        let status = Command::new("powershell")
+            .args([
+                "-NoProfile",
+                "-ExecutionPolicy",
+                "Bypass",
+                "-Command",
+                &script,
+            ])
+            .status()
+            .map_err(|e| AgmError::Other(format!("failed to run powershell: {}", e)))?;
+        if !status.success() {
+            return Err(AgmError::Other("self-update failed".into()));
+        }
+    } else {
+        let env_setup = if force { "AGM_FORCE=1 " } else { "" };
+        let script = format!("curl -fsSL {} | {}bash", INSTALL_SH_URL, env_setup);
+        let status = Command::new("sh")
+            .arg("-c")
+            .arg(&script)
+            .status()
+            .map_err(|e| AgmError::Other(format!("failed to run curl|bash: {}", e)))?;
+        if !status.success() {
+            return Err(AgmError::Other("self-update failed".into()));
+        }
+    }
+
+    Ok(())
+}

--- a/agm/src/commands/uninstall.rs
+++ b/agm/src/commands/uninstall.rs
@@ -1,0 +1,60 @@
+use crate::adapter::get_adapter;
+use crate::error::{AgmError, Result};
+use crate::resolver::PackageType;
+use crate::types::*;
+use std::path::PathBuf;
+
+pub fn execute(package: &str, target: &str, project_dir: Option<PathBuf>) -> Result<()> {
+    let dir = project_dir.unwrap_or_else(|| PathBuf::from("."));
+    let manifest_path = dir.join("agm.json");
+
+    if !manifest_path.exists() {
+        return Err(AgmError::ManifestNotFound);
+    }
+
+    let adapter = get_adapter(target)
+        .ok_or_else(|| AgmError::Other(format!("unknown target: {}", target)))?;
+
+    let mut manifest = ProjectManifest::load(&manifest_path)?;
+
+    let removed_skills = manifest.skills.remove(package);
+    let removed_agents = manifest.agents.remove(package);
+    let removed_mcp = manifest.mcp.remove(package);
+
+    if removed_skills.is_none() && removed_agents.is_none() && removed_mcp.is_none() {
+        return Err(AgmError::PackageNotInManifest(package.into()));
+    }
+
+    let link_name = crate::adapter::symlink_name(package, &[]);
+
+    if removed_skills.is_some() {
+        let target_dir = adapter.map_dir(PackageType::Skills, &dir);
+        adapter.uninstall(&target_dir, &link_name)?;
+    }
+    if removed_agents.is_some() {
+        let target_dir = adapter.map_dir(PackageType::Agents, &dir);
+        adapter.uninstall(&target_dir, &link_name)?;
+    }
+    if removed_mcp.is_some() {
+        let target_dir = adapter.map_dir(PackageType::Mcp, &dir);
+        adapter.uninstall(&target_dir, &link_name)?;
+    }
+
+    manifest.save(&manifest_path)?;
+
+    let lock_path = dir.join("agm.lock.json");
+    if lock_path.exists() {
+        let mut lock = LockFile::load(&lock_path)?;
+        if let Some(importer) = lock.importers.get_mut(".") {
+            importer.skills.remove(package);
+            importer.agents.remove(package);
+            importer.mcp.remove(package);
+        }
+        lock.packages
+            .retain(|k, _| !k.starts_with(&format!("{}@", package)));
+        lock.save(&lock_path)?;
+    }
+
+    println!("Uninstalled {}", package);
+    Ok(())
+}

--- a/agm/src/commands/update.rs
+++ b/agm/src/commands/update.rs
@@ -1,0 +1,12 @@
+use crate::error::Result;
+use std::path::PathBuf;
+
+pub fn execute(project_dir: Option<PathBuf>) -> Result<()> {
+    let dir = project_dir.unwrap_or_else(|| PathBuf::from("."));
+    println!(
+        "Checking for updates in {}... (v1: manual update)",
+        dir.display()
+    );
+    println!("Edit agm.json version ranges and run `agm install` to upgrade.");
+    Ok(())
+}

--- a/agm/src/config.rs
+++ b/agm/src/config.rs
@@ -1,0 +1,77 @@
+use crate::error::Result;
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgmConfig {
+    #[serde(default = "default_registry")]
+    pub default_registry: String,
+    #[serde(default)]
+    pub registry_token: Option<String>,
+    #[serde(default = "default_target")]
+    pub default_target: String,
+    #[serde(default = "default_concurrency")]
+    pub concurrency: usize,
+    #[serde(default = "default_store_path")]
+    pub store_path: PathBuf,
+}
+
+fn default_registry() -> String {
+    "https://registry.agm.dev".into()
+}
+fn default_target() -> String {
+    "claude".into()
+}
+fn default_concurrency() -> usize {
+    4
+}
+fn default_store_path() -> PathBuf {
+    agm_dir().join("store")
+}
+
+impl Default for AgmConfig {
+    fn default() -> Self {
+        Self {
+            default_registry: default_registry(),
+            registry_token: None,
+            default_target: default_target(),
+            concurrency: default_concurrency(),
+            store_path: default_store_path(),
+        }
+    }
+}
+
+pub fn agm_dir() -> PathBuf {
+    dirs_next::home_dir()
+        .expect("cannot find home directory")
+        .join(".agm")
+}
+
+pub fn config_path() -> PathBuf {
+    agm_dir().join("config.json")
+}
+
+impl AgmConfig {
+    pub fn load() -> Result<Self> {
+        let path = config_path();
+        if path.exists() {
+            let content = std::fs::read_to_string(&path)?;
+            Ok(serde_json::from_str(&content)?)
+        } else {
+            Ok(Self::default())
+        }
+    }
+
+    pub fn save(&self) -> Result<()> {
+        let dir = agm_dir();
+        std::fs::create_dir_all(&dir)?;
+        let content = serde_json::to_string_pretty(self)?;
+        std::fs::write(config_path(), content)?;
+        Ok(())
+    }
+
+    pub fn ensure_store_dir(&self) -> Result<PathBuf> {
+        std::fs::create_dir_all(&self.store_path)?;
+        Ok(self.store_path.clone())
+    }
+}

--- a/agm/src/config_test.rs
+++ b/agm/src/config_test.rs
@@ -1,0 +1,18 @@
+use crate::config::*;
+
+#[test]
+fn test_default_config() {
+    let cfg = AgmConfig::default();
+    assert_eq!(cfg.default_registry, "https://registry.agm.dev");
+    assert_eq!(cfg.default_target, "claude");
+    assert_eq!(cfg.concurrency, 4);
+}
+
+#[test]
+fn test_config_roundtrip() {
+    let cfg = AgmConfig::default();
+    let json = serde_json::to_string(&cfg).unwrap();
+    let parsed: AgmConfig = serde_json::from_str(&json).unwrap();
+    assert_eq!(parsed.default_registry, cfg.default_registry);
+    assert_eq!(parsed.concurrency, cfg.concurrency);
+}

--- a/agm/src/error.rs
+++ b/agm/src/error.rs
@@ -1,0 +1,45 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum AgmError {
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("JSON parse error: {0}")]
+    Json(#[from] serde_json::Error),
+
+    #[error("HTTP error: {0}")]
+    Http(#[from] reqwest::Error),
+
+    #[error("Git error: {0}")]
+    Git(String),
+
+    #[error("Manifest not found: agm.json not found in current directory")]
+    ManifestNotFound,
+
+    #[error("Lock file not found: run `agm install` first")]
+    LockNotFound,
+
+    #[error("Package not found in manifest: {0}")]
+    PackageNotInManifest(String),
+
+    #[error("Package not found in store: {0}")]
+    PackageNotInStore(String),
+
+    #[error("Version conflict: {details}")]
+    VersionConflict { details: String },
+
+    #[error("Semver parse error: {0}")]
+    Semver(#[from] semver::Error),
+
+    #[error("Invalid commit hash: {0}")]
+    InvalidCommitHash(String),
+
+    #[error("Registry error: {0}")]
+    Registry(String),
+
+    #[error("{0}")]
+    Other(String),
+}
+
+pub type Result<T> = std::result::Result<T, AgmError>;

--- a/agm/src/git.rs
+++ b/agm/src/git.rs
@@ -1,0 +1,113 @@
+use crate::error::{AgmError, Result};
+use std::path::Path;
+use std::process::Command;
+
+/// git clone 指定仓库到目标目录，checkout 到指定 commit
+pub fn clone_at_commit(repo_url: &str, commit: &str, dest: &Path) -> Result<()> {
+    let output = Command::new("git")
+        .args(["clone", "--no-checkout", repo_url])
+        .arg(dest.as_os_str())
+        .output()
+        .map_err(|e| AgmError::Git(format!("git clone failed: {}", e)))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(AgmError::Git(format!("git clone failed: {}", stderr)));
+    }
+
+    let output = Command::new("git")
+        .args(["checkout", commit])
+        .current_dir(dest)
+        .output()
+        .map_err(|e| AgmError::Git(format!("git checkout failed: {}", e)))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(AgmError::Git(format!("git checkout failed: {}", stderr)));
+    }
+
+    Ok(())
+}
+
+/// 验证 commit hash 是否合法（40 字符 hex）
+pub fn is_valid_commit_hash(hash: &str) -> bool {
+    hash.len() == 40 && hash.chars().all(|c| c.is_ascii_hexdigit())
+}
+
+/// 获取仓库的所有 tags
+pub fn list_tags(repo_dir: &Path) -> Result<Vec<String>> {
+    let output = Command::new("git")
+        .args(["tag", "--list"])
+        .current_dir(repo_dir)
+        .output()
+        .map_err(|e| AgmError::Git(format!("git tag failed: {}", e)))?;
+
+    if !output.status.success() {
+        return Ok(Vec::new());
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect())
+}
+
+/// clone 仓库到目标目录（浅层，仅 HEAD），返回 HEAD commit hash
+pub fn clone_head(repo_url: &str, dest: &Path) -> Result<String> {
+    let output = Command::new("git")
+        .args(["clone", "--depth", "1", "--single-branch", repo_url])
+        .arg(dest.as_os_str())
+        .output()
+        .map_err(|e| AgmError::Git(format!("git clone failed: {}", e)))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(AgmError::Git(format!("git clone failed: {}", stderr)));
+    }
+
+    let output = Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(dest)
+        .output()
+        .map_err(|e| AgmError::Git(format!("git rev-parse failed: {}", e)))?;
+
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+/// 解析仓库 HEAD commit hash（不 clone，用 git ls-remote）
+pub fn resolve_head(repo_url: &str) -> Result<String> {
+    let output = Command::new("git")
+        .args(["ls-remote", "--symref", repo_url, "HEAD"])
+        .output()
+        .map_err(|e| AgmError::Git(format!("git ls-remote failed: {}", e)))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(AgmError::Git(format!("git ls-remote failed: {}", stderr)));
+    }
+
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .find_map(|line| {
+            if line.contains("HEAD") && !line.contains("ref:") {
+                line.split_whitespace().next().map(|s| s.to_string())
+            } else {
+                None
+            }
+        })
+        .ok_or_else(|| AgmError::Git("failed to parse HEAD from ls-remote output".into()))
+}
+
+/// 从 GitHub URL 解析 owner/repo
+pub fn parse_github_url(url: &str) -> Option<(String, String)> {
+    let url = url.trim_end_matches('/').trim_end_matches(".git");
+    // https://github.com/owner/repo
+    if let Some(rest) = url.strip_prefix("https://github.com/") {
+        let parts: Vec<&str> = rest.split('/').collect();
+        if parts.len() >= 2 {
+            return Some((parts[0].to_string(), parts[1].to_string()));
+        }
+    }
+    None
+}

--- a/agm/src/installer.rs
+++ b/agm/src/installer.rs
@@ -1,0 +1,480 @@
+use crate::adapter::*;
+use crate::config::AgmConfig;
+use crate::error::{AgmError, Result};
+use crate::git;
+use crate::registry::RegistryClient;
+use crate::resolver::*;
+use crate::store::*;
+use crate::types::*;
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use tokio::runtime::Runtime;
+
+/// 自动探测结果：(skills, agents)，每个元素为 (name, glob) 对，glob 为 store 内的相对路径
+type DetectedTypes = (Vec<(String, String)>, Vec<(String, String)>);
+
+/// 安装上下文
+pub struct InstallContext {
+    pub config: AgmConfig,
+    pub store: Store,
+    pub manifest: ProjectManifest,
+    pub lock: Option<LockFile>,
+    pub target: String,
+    pub project_root: PathBuf,
+}
+
+impl InstallContext {
+    pub fn new(
+        config: AgmConfig,
+        manifest: ProjectManifest,
+        target: &str,
+        project_root: PathBuf,
+    ) -> Result<Self> {
+        let store = Store::new(config.store_path.clone());
+        store.ensure_root()?;
+
+        // 确保 agm 临时目录存在（与 store 同文件系统，用于原子 rename）
+        let tmp_dir = crate::config::agm_dir().join("tmp");
+        std::fs::create_dir_all(&tmp_dir)?;
+
+        let lock_path = project_root.join("agm.lock.json");
+        let lock = if lock_path.exists() {
+            Some(LockFile::load(&lock_path)?)
+        } else {
+            None
+        };
+
+        Ok(Self {
+            config,
+            store,
+            manifest,
+            lock,
+            target: target.to_string(),
+            project_root,
+        })
+    }
+
+    /// 在 ~/.agm/tmp/ 下创建临时目录，确保与 store 同一文件系统
+    fn temp_dir(&self) -> Result<tempfile::TempDir> {
+        let tmp_root = crate::config::agm_dir().join("tmp");
+        std::fs::create_dir_all(&tmp_root)?;
+        Ok(tempfile::TempDir::new_in(&tmp_root)?)
+    }
+
+    /// 从 git URL 直接安装一个包（类似 npm install <url>）
+    pub fn install_from_git(&mut self, repo_url: &str) -> Result<()> {
+        let adapter = get_adapter(&self.target)
+            .ok_or_else(|| AgmError::Other(format!("unknown target: {}", self.target)))?;
+
+        // 解析 URL → package name
+        let (owner, repo) = git::parse_github_url(repo_url)
+            .ok_or_else(|| AgmError::Other(format!("unsupported git URL: {}", repo_url)))?;
+        let pkg_name = format!("@git/{}/{}", owner, repo);
+
+        // 先用 ls-remote 拿 HEAD hash，检查 store 是否已有
+        let head_commit = git::resolve_head(repo_url)?;
+        let store_path = self.store.git_package_path(repo_url, &head_commit);
+
+        let (skills, agents, store_path, actual_commit, resolution) = if store_path.exists() {
+            println!("  (already in store, skipping clone)");
+            let pkg_manifest_path = store_path.join("agm.package.json");
+            let (skills, agents) = if pkg_manifest_path.exists() {
+                let pkg = PackageManifest::load(&pkg_manifest_path)?;
+                let skills: Vec<_> = pkg
+                    .skills
+                    .into_iter()
+                    .map(|g| {
+                        let n = extract_skill_name(&g);
+                        (n, g)
+                    })
+                    .collect();
+                let agents: Vec<_> = pkg
+                    .agents
+                    .into_iter()
+                    .map(|g| {
+                        let n = extract_skill_name(&g);
+                        (n, g)
+                    })
+                    .collect();
+                (skills, agents)
+            } else {
+                self.auto_detect_types(&store_path)
+            };
+            let resolution = Resolution::Git {
+                repo: repo_url.to_string(),
+                commit: head_commit.clone(),
+            };
+            (skills, agents, store_path, head_commit.clone(), resolution)
+        } else {
+            let temp_dir = self.temp_dir()?;
+            let cloned_commit = git::clone_head(repo_url, temp_dir.path())?;
+            tracing::info!("cloned {} at commit {}", repo_url, &cloned_commit[..12]);
+
+            if cloned_commit != head_commit {
+                tracing::warn!(
+                    "HEAD changed during clone (expected {}, got {})",
+                    &head_commit[..12],
+                    &cloned_commit[..12]
+                );
+            }
+
+            let pkg_manifest_path = temp_dir.path().join("agm.package.json");
+            let (skills, agents) = if pkg_manifest_path.exists() {
+                let pkg = PackageManifest::load(&pkg_manifest_path)?;
+                let skills: Vec<_> = pkg
+                    .skills
+                    .into_iter()
+                    .map(|g| {
+                        let n = extract_skill_name(&g);
+                        (n, g)
+                    })
+                    .collect();
+                let agents: Vec<_> = pkg
+                    .agents
+                    .into_iter()
+                    .map(|g| {
+                        let n = extract_skill_name(&g);
+                        (n, g)
+                    })
+                    .collect();
+                (skills, agents)
+            } else {
+                self.auto_detect_types(temp_dir.path())
+            };
+
+            let resolution = Resolution::Git {
+                repo: repo_url.to_string(),
+                commit: cloned_commit.clone(),
+            };
+            let store_path = install_to_store(
+                &self.store,
+                temp_dir.path(),
+                &resolution,
+                &pkg_name,
+                &cloned_commit,
+            )?;
+            let _ = temp_dir.close();
+            (skills, agents, store_path, cloned_commit, resolution)
+        };
+
+        let mut installed = Vec::new();
+
+        // 为 skills 创建 symlink
+        for (skill_name, skill_glob) in &skills {
+            let target_dir = adapter.map_dir(PackageType::Skills, &self.project_root);
+            let link_name = symlink_name(skill_name, &[]);
+            let store_skill_path = store_path.join(skill_glob);
+            if store_skill_path.exists() {
+                let parent = store_skill_path.parent().unwrap_or(&store_skill_path);
+                adapter
+                    .install(parent, &target_dir, &link_name)
+                    .map_err(|e| AgmError::Other(format!("symlink skill {}: {}", skill_name, e)))?;
+                println!(
+                    "  ✓ skill: {} → .{}/skills/{}",
+                    skill_name, self.target, link_name
+                );
+                self.manifest
+                    .skills
+                    .insert(pkg_name.clone(), actual_commit.clone());
+                installed.push((pkg_name.clone(), actual_commit.clone(), resolution.clone()));
+            }
+        }
+
+        // 为 agents 创建 symlink
+        for (agent_name, agent_glob) in &agents {
+            let target_dir = adapter.map_dir(PackageType::Agents, &self.project_root);
+            let link_name = symlink_name(agent_name, &[]);
+            let store_agent_path = store_path.join(agent_glob);
+            if store_agent_path.exists() {
+                adapter
+                    .install(&store_agent_path, &target_dir, &link_name)
+                    .map_err(|e| AgmError::Other(format!("symlink agent {}: {}", agent_name, e)))?;
+                println!(
+                    "  ✓ agent: {} → .{}/agents/{}",
+                    agent_name, self.target, link_name
+                );
+                self.manifest
+                    .agents
+                    .insert(pkg_name.clone(), actual_commit.clone());
+                if !installed.iter().any(|(n, _, _)| n == &pkg_name) {
+                    installed.push((pkg_name.clone(), actual_commit.clone(), resolution.clone()));
+                }
+            }
+        }
+
+        if skills.is_empty() && agents.is_empty() {
+            println!("No skills or agents found in the repo. If the repo has an agm.package.json, it should declare exports.");
+        }
+
+        // 保存 agm.json
+        let manifest_path = self.project_root.join("agm.json");
+        self.manifest
+            .save(&manifest_path)
+            .map_err(|e| AgmError::Other(format!("save agm.json: {}", e)))?;
+
+        // 更新 lock
+        self.update_lock(&installed)
+            .map_err(|e| AgmError::Other(format!("update lock: {}", e)))?;
+
+        adapter
+            .post_install()
+            .map_err(|e| AgmError::Other(format!("post_install: {}", e)))?;
+        Ok(())
+    }
+
+    /// 自动探测 repo 中的 skills 和 agents（无 agm.package.json 时）
+    /// 返回 (name, glob) 对，glob 为 store 内的相对路径
+    fn auto_detect_types(&self, repo_root: &Path) -> DetectedTypes {
+        let mut skills: Vec<(String, String)> = Vec::new();
+        let mut agents: Vec<(String, String)> = Vec::new();
+
+        // 探测 .{tool}/skills/**/SKILL.md（递归支持嵌套分类目录）
+        for tool_prefix in &[".claude", ".codex", ".copilot", ""] {
+            let skills_dir = if tool_prefix.is_empty() {
+                repo_root.join("skills")
+            } else {
+                repo_root.join(tool_prefix).join("skills")
+            };
+            skills.extend(find_skills_recursive(&skills_dir, repo_root));
+
+            // 探测 .{tool}/agents/*.md
+            let agents_dir = if tool_prefix.is_empty() {
+                repo_root.join("agents")
+            } else {
+                repo_root.join(tool_prefix).join("agents")
+            };
+            if let Ok(entries) = std::fs::read_dir(&agents_dir) {
+                for entry in entries.flatten() {
+                    let path = entry.path();
+                    if path.is_file() && path.extension().is_some_and(|e| e == "md") {
+                        let name = path.file_stem().unwrap().to_string_lossy().to_string();
+                        let prefix = if tool_prefix.is_empty() {
+                            "agents".to_string()
+                        } else {
+                            format!("{}/agents", tool_prefix)
+                        };
+                        let glob = format!("{}/{}.md", prefix, name);
+                        tracing::info!("auto-detected agent: {} ({})", name, glob);
+                        agents.push((name, glob));
+                    }
+                }
+            }
+        }
+
+        (skills, agents)
+    }
+}
+
+/// 递归查找包含 SKILL.md 的目录，支持嵌套分类（如 skills/engineering/grill-me/SKILL.md）
+/// 返回 (skill名, 相对于 repo_root 的 SKILL.md 路径)
+fn find_skills_recursive(base_dir: &Path, repo_root: &Path) -> Vec<(String, String)> {
+    let mut result = Vec::new();
+    let entries = match std::fs::read_dir(base_dir) {
+        Ok(e) => e,
+        Err(_) => return result,
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        let skill_md = path.join("SKILL.md");
+        if skill_md.exists() {
+            let name = path.file_name().unwrap().to_string_lossy().to_string();
+            let rel = skill_md.strip_prefix(repo_root).unwrap_or(&skill_md);
+            let glob = rel.to_string_lossy().to_string();
+            tracing::info!("auto-detected skill: {} ({})", name, glob);
+            result.push((name, glob));
+        } else {
+            // 递归进入子目录（如 skills/engineering/, skills/productivity/）
+            result.extend(find_skills_recursive(&path, repo_root));
+        }
+    }
+    result
+}
+
+impl InstallContext {
+    pub fn install_all(&mut self) -> Result<()> {
+        let adapter = get_adapter(&self.target)
+            .ok_or_else(|| AgmError::Other(format!("unknown target: {}", self.target)))?;
+
+        let deps = collect_dependencies(&self.manifest);
+
+        if deps.is_empty() {
+            tracing::info!("no dependencies to install");
+            return Ok(());
+        }
+
+        let registry_url = self
+            .manifest
+            .registry
+            .as_deref()
+            .unwrap_or(&self.config.default_registry);
+        let registry_client = RegistryClient::new(registry_url, self.config.registry_token.clone());
+
+        let types = [PackageType::Skills, PackageType::Agents, PackageType::Mcp];
+        let mut installed_packages: Vec<(String, String, Resolution)> = Vec::new();
+        let rt = Runtime::new()?;
+
+        for typ in &types {
+            let deps_of_type: Vec<_> = deps.iter().filter(|(_, _, t)| t == typ).collect();
+
+            for (name, version, _) in &deps_of_type {
+                let lock_version: String;
+                let resolution;
+
+                if is_git_dep(name) {
+                    validate_commit_hash(version)?;
+                    lock_version = version.clone();
+
+                    let pkg_key = format!("{}@{}", name, lock_version);
+                    if let Some(lock) = &self.lock {
+                        if lock.packages.contains_key(&pkg_key) {
+                            continue;
+                        }
+                    }
+
+                    let temp_dir = self.temp_dir()?;
+                    let repo_url =
+                        format!("https://github.com/{}", name.trim_start_matches("@git/"));
+                    git::clone_at_commit(&repo_url, version, temp_dir.path())?;
+
+                    resolution = Resolution::Git {
+                        repo: repo_url,
+                        commit: version.clone(),
+                    };
+
+                    install_to_store(&self.store, temp_dir.path(), &resolution, name, version)?;
+                    let _ = temp_dir.close();
+                } else {
+                    let resolved_version =
+                        rt.block_on(resolve_registry_version(&registry_client, name, version))?;
+                    lock_version = resolved_version.clone();
+
+                    let pkg_key = format!("{}@{}", name, lock_version);
+                    if let Some(lock) = &self.lock {
+                        if lock.packages.contains_key(&pkg_key) {
+                            continue;
+                        }
+                    }
+
+                    let version_meta =
+                        rt.block_on(registry_client.get_version(name, &resolved_version))?;
+
+                    let temp_dir = self.temp_dir()?;
+                    let tarball_path = temp_dir.path().join("pkg.tar.gz");
+                    rt.block_on(registry_client.download_tarball(
+                        name,
+                        &version_meta.tarball,
+                        &tarball_path,
+                    ))?;
+
+                    let extract_dir = temp_dir.path().join("extracted");
+                    std::fs::create_dir(&extract_dir)?;
+                    extract_tarball(&tarball_path, &extract_dir)?;
+
+                    resolution = Resolution::Registry {
+                        integrity: version_meta.integrity.clone(),
+                    };
+
+                    install_to_store(
+                        &self.store,
+                        &extract_dir,
+                        &resolution,
+                        name,
+                        &resolved_version,
+                    )?;
+                }
+
+                // 建 symlink
+                let target_dir = adapter.map_dir(*typ, &self.project_root);
+                let link_name = symlink_name(name, &[]);
+                let store_path = match &resolution {
+                    Resolution::Git { repo, commit, .. } => {
+                        self.store.git_package_path(repo, commit)
+                    }
+                    Resolution::Registry { .. } => {
+                        self.store.registry_package_path(name, &lock_version)
+                    }
+                };
+                adapter.install(&store_path, &target_dir, &link_name)?;
+
+                installed_packages.push((name.clone(), lock_version, resolution));
+            }
+        }
+
+        adapter.post_install()?;
+        self.update_lock(&installed_packages)
+    }
+
+    fn update_lock(&self, installed: &[(String, String, Resolution)]) -> Result<()> {
+        let mut lock = self.lock.clone().unwrap_or_else(|| LockFile {
+            lockfile_version: 1,
+            importers: BTreeMap::new(),
+            packages: BTreeMap::new(),
+        });
+
+        let importer = lock
+            .importers
+            .entry(".".into())
+            .or_insert_with(|| LockImporter {
+                skills: BTreeMap::new(),
+                agents: BTreeMap::new(),
+                mcp: BTreeMap::new(),
+            });
+
+        for (name, version, _) in installed {
+            let dep = LockDependency {
+                version: version.clone(),
+            };
+            if self.manifest.skills.contains_key(name) {
+                importer.skills.insert(name.clone(), dep);
+            } else if self.manifest.agents.contains_key(name) {
+                importer.agents.insert(name.clone(), dep);
+            } else if self.manifest.mcp.contains_key(name) {
+                importer.mcp.insert(name.clone(), dep);
+            }
+        }
+
+        for (name, version, resolution) in installed {
+            let pkg_key = format!("{}@{}", name, version);
+            lock.packages
+                .entry(pkg_key)
+                .or_insert_with(|| LockedPackage {
+                    resolution: resolution.clone(),
+                    targets: vec![self.target.clone()],
+                });
+        }
+
+        let lock_path = self.project_root.join("agm.lock.json");
+        lock.save(&lock_path)?;
+        Ok(())
+    }
+}
+
+/// 解压 .tar.gz tarball
+fn extract_tarball(tarball_path: &Path, dest: &Path) -> Result<()> {
+    let file = std::fs::File::open(tarball_path)?;
+    let decoder = flate2::read::GzDecoder::new(file);
+    let mut archive = tar::Archive::new(decoder);
+    archive.unpack(dest)?;
+    Ok(())
+}
+
+/// 从 glob 路径提取 skill/agent 名称（如 ".claude/skills/interview/SKILL.md" → "interview"）
+fn extract_skill_name(glob: &str) -> String {
+    let parts: Vec<&str> = glob.split('/').collect();
+    // 找 "skills" 或 "agents" 后面的部分
+    for (i, part) in parts.iter().enumerate() {
+        if (*part == "skills" || *part == "agents") && i + 1 < parts.len() {
+            return parts[i + 1].to_string();
+        }
+    }
+    // fallback: 用最后一个有意义的目录名
+    parts
+        .iter()
+        .rev()
+        .find(|p| !p.ends_with(".md") && **p != "SKILL.md")
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| "unknown".into())
+}

--- a/agm/src/lib.rs
+++ b/agm/src/lib.rs
@@ -1,0 +1,21 @@
+pub mod commands;
+pub mod error;
+pub mod types;
+pub use error::{AgmError, Result};
+
+pub mod adapter;
+pub mod config;
+pub mod git;
+pub mod installer;
+pub mod registry;
+pub mod resolver;
+pub mod store;
+
+#[cfg(test)]
+mod config_test;
+
+#[cfg(test)]
+mod types_test;
+
+#[cfg(test)]
+mod store_test;

--- a/agm/src/main.rs
+++ b/agm/src/main.rs
@@ -1,0 +1,89 @@
+use clap::{Parser, Subcommand};
+use std::path::PathBuf;
+
+#[derive(Parser)]
+#[command(name = "agm", about = "Agent Package Manager")]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+
+    /// 项目目录（默认当前目录）
+    #[arg(short = 'C', long, default_value = ".", global = true)]
+    dir: Option<String>,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// 生成 agm.json 模板
+    Init,
+
+    /// 安装所有依赖到目标工具
+    Install {
+        /// 目标工具 (claude, codex, copilot)
+        #[arg(long, default_value = "claude")]
+        tool: String,
+
+        /// 从 git URL 直接安装（如 https://github.com/user/repo）
+        #[arg(long)]
+        git: Option<String>,
+    },
+
+    /// 卸载一个包
+    Uninstall {
+        /// 包名
+        package: String,
+        /// 目标工具
+        #[arg(long, default_value = "claude")]
+        tool: String,
+    },
+
+    /// 检查可升级的包
+    Update,
+
+    /// 列出所有依赖
+    List,
+
+    /// 发布包到 registry
+    Publish {
+        /// Registry URL
+        #[arg(long)]
+        registry: Option<String>,
+    },
+
+    /// 清理 store 中的孤儿包
+    Gc,
+
+    /// 更新 agm 自身
+    SelfUpdate {
+        /// 强制重新安装（即使已是最新）
+        #[arg(long)]
+        force: bool,
+    },
+}
+
+fn main() {
+    tracing_subscriber::fmt::init();
+
+    let cli = Cli::parse();
+    let dir = cli.dir.map(PathBuf::from);
+
+    let result = match cli.command {
+        Commands::Init => agm::commands::init::execute(dir),
+        Commands::Install { tool, git } => {
+            agm::commands::install::execute(&tool, git.as_deref(), dir)
+        }
+        Commands::Uninstall { package, tool } => {
+            agm::commands::uninstall::execute(&package, &tool, dir)
+        }
+        Commands::Update => agm::commands::update::execute(dir),
+        Commands::List => agm::commands::list::execute(dir),
+        Commands::Publish { registry } => agm::commands::publish::execute(registry, dir),
+        Commands::Gc => agm::commands::gc::execute(),
+        Commands::SelfUpdate { force } => agm::commands::self_update::execute(force),
+    };
+
+    if let Err(e) = result {
+        eprintln!("Error: {}", e);
+        std::process::exit(1);
+    }
+}

--- a/agm/src/registry.rs
+++ b/agm/src/registry.rs
@@ -1,0 +1,111 @@
+use crate::error::{AgmError, Result};
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::path::Path;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PackageMetadata {
+    pub name: String,
+    pub versions: BTreeMap<String, VersionMetadata>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VersionMetadata {
+    pub version: String,
+    pub integrity: String,
+    pub tarball: String,
+    #[serde(default)]
+    pub dependencies: BTreeMap<String, String>,
+}
+
+pub struct RegistryClient {
+    client: Client,
+    base_url: String,
+    token: Option<String>,
+}
+
+impl RegistryClient {
+    pub fn new(base_url: &str, token: Option<String>) -> Self {
+        Self {
+            client: Client::new(),
+            base_url: base_url.trim_end_matches('/').to_string(),
+            token,
+        }
+    }
+
+    fn auth_header(&self) -> Option<String> {
+        self.token.as_ref().map(|t| format!("Bearer {}", t))
+    }
+
+    /// GET /packages/:name — 获取包元数据
+    pub async fn get_package(&self, name: &str) -> Result<PackageMetadata> {
+        let url = format!("{}/packages/{}", self.base_url, name);
+        let mut req = self.client.get(&url);
+        if let Some(auth) = self.auth_header() {
+            req = req.header("Authorization", auth);
+        }
+        let resp = req.send().await?;
+        if !resp.status().is_success() {
+            return Err(AgmError::Registry(format!(
+                "failed to fetch package: HTTP {}",
+                resp.status()
+            )));
+        }
+        Ok(resp.json().await?)
+    }
+
+    /// GET /packages/:name/:version — 获取版本元数据
+    pub async fn get_version(&self, name: &str, version: &str) -> Result<VersionMetadata> {
+        let url = format!("{}/packages/{}/{}", self.base_url, name, version);
+        let mut req = self.client.get(&url);
+        if let Some(auth) = self.auth_header() {
+            req = req.header("Authorization", auth);
+        }
+        let resp = req.send().await?;
+        if !resp.status().is_success() {
+            return Err(AgmError::Registry(format!(
+                "failed to fetch version: HTTP {}",
+                resp.status()
+            )));
+        }
+        Ok(resp.json().await?)
+    }
+
+    /// GET /packages/:name/-/:tarball — 下载 tarball
+    pub async fn download_tarball(&self, name: &str, tarball: &str, dest: &Path) -> Result<()> {
+        let url = format!("{}/packages/{}/-/{}", self.base_url, name, tarball);
+        let mut req = self.client.get(&url);
+        if let Some(auth) = self.auth_header() {
+            req = req.header("Authorization", auth);
+        }
+        let resp = req.send().await?;
+        if !resp.status().is_success() {
+            return Err(AgmError::Registry(format!(
+                "failed to download tarball: HTTP {}",
+                resp.status()
+            )));
+        }
+        let bytes = resp.bytes().await?;
+        std::fs::write(dest, bytes)?;
+        Ok(())
+    }
+
+    /// PUT /packages/:name — publish
+    pub async fn publish(&self, name: &str, tarball_path: &Path) -> Result<()> {
+        let url = format!("{}/packages/{}", self.base_url, name);
+        let data = std::fs::read(tarball_path)?;
+        let mut req = self.client.put(&url).body(data);
+        if let Some(auth) = self.auth_header() {
+            req = req.header("Authorization", auth);
+        }
+        let resp = req.send().await?;
+        if !resp.status().is_success() {
+            return Err(AgmError::Registry(format!(
+                "failed to publish: HTTP {}",
+                resp.status()
+            )));
+        }
+        Ok(())
+    }
+}

--- a/agm/src/resolver.rs
+++ b/agm/src/resolver.rs
@@ -1,0 +1,90 @@
+use crate::error::{AgmError, Result};
+use crate::git;
+use crate::registry::RegistryClient;
+use crate::types::*;
+use semver::VersionReq;
+use std::collections::BTreeMap;
+
+/// 解析结果
+#[derive(Debug, Clone)]
+pub struct ResolvedPackage {
+    pub name: String,
+    pub version: String,
+    pub resolution: Resolution,
+}
+
+/// 判断是否为 git 依赖（@git/ 前缀）
+pub fn is_git_dep(name: &str) -> bool {
+    name.starts_with("@git/")
+}
+
+/// 验证 git commit hash
+pub fn validate_commit_hash(hash: &str) -> Result<()> {
+    if !git::is_valid_commit_hash(hash) {
+        return Err(AgmError::InvalidCommitHash(hash.into()));
+    }
+    Ok(())
+}
+
+/// 从 registry 解析 semver range 到具体版本
+pub async fn resolve_registry_version(
+    client: &RegistryClient,
+    name: &str,
+    range: &str,
+) -> Result<String> {
+    let req = VersionReq::parse(range)?;
+    let metadata = client.get_package(name).await?;
+
+    let mut candidates: Vec<_> = metadata.versions.keys().cloned().collect();
+    candidates.sort_by(|a, b| {
+        let va = semver::Version::parse(a).ok();
+        let vb = semver::Version::parse(b).ok();
+        vb.cmp(&va) // 降序
+    });
+
+    for version in &candidates {
+        if let Ok(v) = semver::Version::parse(version) {
+            if req.matches(&v) {
+                return Ok(version.clone());
+            }
+        }
+    }
+
+    Err(AgmError::Other(format!(
+        "no version of {} satisfies range {}",
+        name, range
+    )))
+}
+
+/// 从 manifest 收集所有需要解析的依赖
+pub fn collect_dependencies(manifest: &ProjectManifest) -> Vec<(String, String, PackageType)> {
+    let mut deps = Vec::new();
+    for (name, version) in &manifest.skills {
+        deps.push((name.clone(), version.clone(), PackageType::Skills));
+    }
+    for (name, version) in &manifest.agents {
+        deps.push((name.clone(), version.clone(), PackageType::Agents));
+    }
+    for (name, version) in &manifest.mcp {
+        deps.push((name.clone(), version.clone(), PackageType::Mcp));
+    }
+    deps
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PackageType {
+    Skills,
+    Agents,
+    Mcp,
+}
+
+/// 检测传递依赖冲突
+pub fn detect_conflicts(
+    resolved: &BTreeMap<String, ResolvedPackage>,
+    overrides: &BTreeMap<String, String>,
+) -> Result<()> {
+    for name in overrides.keys() {
+        let _found = resolved.values().any(|p| p.name == *name);
+    }
+    Ok(())
+}

--- a/agm/src/store.rs
+++ b/agm/src/store.rs
@@ -1,0 +1,105 @@
+use crate::error::{AgmError, Result};
+use crate::types::{PackageManifest, Resolution};
+use std::path::{Path, PathBuf};
+
+/// Store 管理器：~/.agm/store/
+pub struct Store {
+    pub(crate) root: PathBuf,
+}
+
+impl Store {
+    pub fn new(root: PathBuf) -> Self {
+        Self { root }
+    }
+
+    /// 获取 git 包在 store 中的路径: store/git_{owner}_{repo}@{commit}/
+    pub fn git_package_path(&self, repo_url: &str, commit: &str) -> PathBuf {
+        let id = sanitize_repo_id(repo_url);
+        self.root
+            .join(format!("git_{id}@{commit}", id = id, commit = commit))
+    }
+
+    /// 获取 registry 包在 store 中的路径: store/<name>@<version>/
+    pub fn registry_package_path(&self, name: &str, version: &str) -> PathBuf {
+        let safe_name = name.replace('/', "_");
+        self.root.join(format!("{}@{}", safe_name, version))
+    }
+
+    /// 确保 store 根目录存在
+    pub fn ensure_root(&self) -> Result<()> {
+        std::fs::create_dir_all(&self.root)?;
+        Ok(())
+    }
+
+    /// 列出 store 中所有包目录
+    pub fn list_packages(&self) -> Result<Vec<PathBuf>> {
+        let mut entries = Vec::new();
+        if !self.root.exists() {
+            return Ok(entries);
+        }
+        for entry in std::fs::read_dir(&self.root)? {
+            let entry = entry?;
+            if entry.file_type()?.is_dir() {
+                entries.push(entry.path());
+            }
+        }
+        Ok(entries)
+    }
+
+    /// 读取包内 agm.package.json
+    pub fn read_package_manifest(&self, package_dir: &Path) -> Result<PackageManifest> {
+        let manifest_path = package_dir.join("agm.package.json");
+        if !manifest_path.exists() {
+            return Err(AgmError::Other(format!(
+                "agm.package.json not found in {}",
+                package_dir.display()
+            )));
+        }
+        PackageManifest::load(&manifest_path)
+    }
+
+    /// 删除指定包目录
+    pub fn remove(&self, package_dir: &Path) -> Result<()> {
+        if package_dir.exists() {
+            std::fs::remove_dir_all(package_dir)?;
+        }
+        Ok(())
+    }
+}
+
+/// 将 repo URL 转为安全的文件系统标识
+fn sanitize_repo_id(url: &str) -> String {
+    url.trim_end_matches('/')
+        .trim_end_matches(".git")
+        .trim_start_matches("https://")
+        .trim_start_matches("http://")
+        .trim_start_matches("git@")
+        .replace("github.com/", "")
+        .replace(':', "/")
+        .replace(['/', '@'], "_")
+}
+
+/// 将包从临时目录安装到 store
+pub fn install_to_store(
+    store: &Store,
+    temp_dir: &Path,
+    resolution: &Resolution,
+    pkg_name: &str,
+    version: &str,
+) -> Result<PathBuf> {
+    let dest = match resolution {
+        Resolution::Git { repo, commit, .. } => store.git_package_path(repo, commit),
+        Resolution::Registry { .. } => store.registry_package_path(pkg_name, version),
+    };
+
+    if dest.exists() {
+        return Ok(dest);
+    }
+
+    store.ensure_root()?;
+
+    std::fs::rename(temp_dir, &dest)
+        .map_err(|e| AgmError::Other(format!("failed to move package to store: {}", e)))?;
+
+    Ok(dest)
+}

--- a/agm/src/store_test.rs
+++ b/agm/src/store_test.rs
@@ -1,0 +1,59 @@
+use crate::store::*;
+use crate::types::*;
+use std::path::PathBuf;
+
+#[test]
+fn test_git_package_path() {
+    let store = Store::new(PathBuf::from("/tmp/agm-store"));
+    let path = store.git_package_path("https://github.com/user/repo", "abc123def456");
+    assert_eq!(
+        path,
+        PathBuf::from("/tmp/agm-store/git_user_repo@abc123def456")
+    );
+}
+
+#[test]
+fn test_registry_package_path() {
+    let store = Store::new(PathBuf::from("/tmp/agm-store"));
+    let path = store.registry_package_path("scope/pkg", "1.2.3");
+    assert_eq!(path, PathBuf::from("/tmp/agm-store/scope_pkg@1.2.3"));
+}
+
+#[test]
+fn test_ensure_root_creates_dir() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let store = Store::new(tmp.path().join("store"));
+    assert!(!store.root.exists());
+    store.ensure_root().unwrap();
+    assert!(store.root.exists());
+}
+
+#[test]
+fn test_install_to_store_git() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let store = Store::new(tmp.path().join("store"));
+    let src = tmp.path().join("pkg");
+    std::fs::create_dir_all(&src).unwrap();
+    std::fs::write(src.join("SKILL.md"), "# Skill").unwrap();
+
+    let resolution = Resolution::Git {
+        repo: "https://github.com/foo/bar".into(),
+        commit: "abc123".into(),
+    };
+
+    let dest = install_to_store(&store, &src, &resolution, "@git/foo/bar", "abc123").unwrap();
+    assert!(dest.exists());
+    assert!(dest.join("SKILL.md").exists());
+}
+
+#[test]
+fn test_list_packages() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let store = Store::new(tmp.path().join("store"));
+    store.ensure_root().unwrap();
+    std::fs::create_dir(store.root.join("pkg_a@1.0.0")).unwrap();
+    std::fs::create_dir(store.root.join("pkg_b@2.0.0")).unwrap();
+
+    let pkgs = store.list_packages().unwrap();
+    assert_eq!(pkgs.len(), 2);
+}

--- a/agm/src/types.rs
+++ b/agm/src/types.rs
@@ -1,0 +1,130 @@
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use crate::error::Result;
+
+/// agm.json — 项目 manifest
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProjectManifest {
+    pub name: String,
+    #[serde(default = "default_version")]
+    pub version: String,
+    #[serde(default)]
+    pub description: String,
+    #[serde(default)]
+    pub author: String,
+    #[serde(default)]
+    pub registry: Option<String>,
+    #[serde(default)]
+    pub targets: Vec<String>,
+    #[serde(default)]
+    pub skills: BTreeMap<String, String>,
+    #[serde(default)]
+    pub agents: BTreeMap<String, String>,
+    #[serde(default)]
+    pub mcp: BTreeMap<String, String>,
+    #[serde(default)]
+    pub overrides: BTreeMap<String, String>,
+}
+
+fn default_version() -> String {
+    "0.1.0".into()
+}
+
+/// agm.lock.json — lock file
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LockFile {
+    #[serde(default = "default_lockfile_version")]
+    pub lockfile_version: u32,
+    pub importers: BTreeMap<String, LockImporter>,
+    pub packages: BTreeMap<String, LockedPackage>,
+}
+
+fn default_lockfile_version() -> u32 {
+    1
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LockImporter {
+    #[serde(default)]
+    pub skills: BTreeMap<String, LockDependency>,
+    #[serde(default)]
+    pub agents: BTreeMap<String, LockDependency>,
+    #[serde(default)]
+    pub mcp: BTreeMap<String, LockDependency>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LockDependency {
+    pub version: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LockedPackage {
+    pub resolution: Resolution,
+    #[serde(default)]
+    pub targets: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum Resolution {
+    #[serde(rename = "git")]
+    Git { repo: String, commit: String },
+    #[serde(rename = "registry")]
+    Registry { integrity: String },
+}
+
+/// agm.package.json — 包内 manifest
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PackageManifest {
+    pub name: String,
+    #[serde(default = "default_version")]
+    pub version: String,
+    #[serde(default)]
+    pub description: String,
+    #[serde(default)]
+    pub skills: Vec<String>,
+    #[serde(default)]
+    pub agents: Vec<String>,
+    #[serde(default)]
+    pub mcp: Vec<String>,
+}
+
+impl ProjectManifest {
+    pub fn load(path: &Path) -> Result<Self> {
+        let content = std::fs::read_to_string(path)?;
+        Ok(serde_json::from_str(&content)?)
+    }
+
+    pub fn save(&self, path: &Path) -> Result<()> {
+        let content = serde_json::to_string_pretty(self)?;
+        std::fs::write(path, content)?;
+        Ok(())
+    }
+}
+
+impl LockFile {
+    pub fn load(path: &Path) -> Result<Self> {
+        let content = std::fs::read_to_string(path)?;
+        Ok(serde_json::from_str(&content)?)
+    }
+
+    pub fn save(&self, path: &Path) -> Result<()> {
+        let content = serde_json::to_string_pretty(self)?;
+        std::fs::write(path, content)?;
+        Ok(())
+    }
+}
+
+impl PackageManifest {
+    pub fn load(path: &Path) -> Result<Self> {
+        let content = std::fs::read_to_string(path)?;
+        Ok(serde_json::from_str(&content)?)
+    }
+}

--- a/agm/src/types_test.rs
+++ b/agm/src/types_test.rs
@@ -1,0 +1,129 @@
+use crate::types::*;
+use std::collections::BTreeMap;
+
+#[test]
+fn test_parse_project_manifest() {
+    let json = r#"{
+        "name": "my-agent-project",
+        "version": "1.0.0",
+        "skills": {
+            "@git/konghayao/peri/blog-writer": "abc123def456",
+            "some-pkg": "^1.2.3"
+        },
+        "agents": {},
+        "mcp": {}
+    }"#;
+    let manifest: ProjectManifest = serde_json::from_str(json).unwrap();
+    assert_eq!(manifest.name, "my-agent-project");
+    assert_eq!(manifest.skills.len(), 2);
+    assert_eq!(
+        manifest.skills["@git/konghayao/peri/blog-writer"],
+        "abc123def456"
+    );
+    assert_eq!(manifest.skills["some-pkg"], "^1.2.3");
+}
+
+#[test]
+fn test_parse_lock_file() {
+    let json = r#"{
+        "lockfileVersion": 2,
+        "importers": {
+            ".": {
+                "skills": {
+                    "@git/konghayao/peri/blog-writer": { "version": "abc123def456" }
+                }
+            }
+        },
+        "packages": {
+            "@git/konghayao/peri/blog-writer@abc123def456": {
+                "resolution": {
+                    "type": "git",
+                    "repo": "https://github.com/konghayao/peri",
+                    "commit": "abc123def456"
+                },
+                "targets": ["claude"]
+            }
+        }
+    }"#;
+    let lock: LockFile = serde_json::from_str(json).unwrap();
+    assert_eq!(lock.lockfile_version, 2);
+    let pkg = &lock.packages["@git/konghayao/peri/blog-writer@abc123def456"];
+    assert_eq!(pkg.targets, vec!["claude"]);
+    match &pkg.resolution {
+        Resolution::Git { repo, commit } => {
+            assert_eq!(repo, "https://github.com/konghayao/peri");
+            assert_eq!(commit, "abc123def456");
+        }
+        _ => panic!("expected git resolution"),
+    }
+}
+
+#[test]
+fn test_parse_package_manifest() {
+    let json = r#"{
+        "name": "@git/konghayao/peri/blog-writer",
+        "version": "1.0.0",
+        "skills": ["export/skills/blog-writer/SKILL.md"],
+        "agents": [],
+        "mcp": []
+    }"#;
+    let pkg: PackageManifest = serde_json::from_str(json).unwrap();
+    assert_eq!(pkg.name, "@git/konghayao/peri/blog-writer");
+    assert_eq!(pkg.skills, vec!["export/skills/blog-writer/SKILL.md"]);
+}
+
+#[test]
+fn test_project_manifest_roundtrip() {
+    let manifest = ProjectManifest {
+        name: "test".into(),
+        version: "1.0.0".into(),
+        description: String::new(),
+        author: String::new(),
+        registry: None,
+        targets: vec![],
+        skills: [("pkg".into(), "^1.0.0".into())].into(),
+        agents: BTreeMap::new(),
+        mcp: BTreeMap::new(),
+        overrides: BTreeMap::new(),
+    };
+    let json = serde_json::to_string(&manifest).unwrap();
+    let parsed: ProjectManifest = serde_json::from_str(&json).unwrap();
+    assert_eq!(parsed.name, "test");
+    assert_eq!(parsed.skills["pkg"], "^1.0.0");
+}
+
+#[test]
+fn test_lock_file_roundtrip() {
+    let lock = LockFile {
+        lockfile_version: 1,
+        importers: [(
+            ".".into(),
+            LockImporter {
+                skills: [(
+                    "pkg".into(),
+                    LockDependency {
+                        version: "1.0.0".into(),
+                    },
+                )]
+                .into(),
+                agents: BTreeMap::new(),
+                mcp: BTreeMap::new(),
+            },
+        )]
+        .into(),
+        packages: [(
+            "pkg@1.0.0".into(),
+            LockedPackage {
+                resolution: Resolution::Registry {
+                    integrity: "sha256-abc".into(),
+                },
+                targets: vec!["claude".into()],
+            },
+        )]
+        .into(),
+    };
+    let json = serde_json::to_string(&lock).unwrap();
+    let parsed: LockFile = serde_json::from_str(&json).unwrap();
+    assert_eq!(parsed.lockfile_version, 1);
+    assert_eq!(parsed.packages["pkg@1.0.0"].targets, vec!["claude"]);
+}

--- a/agm/tests/integration_test.rs
+++ b/agm/tests/integration_test.rs
@@ -1,0 +1,73 @@
+use std::process::Command;
+use tempfile::TempDir;
+
+#[test]
+fn test_init_creates_agm_json() {
+    let tmp = TempDir::new().unwrap();
+    let output = Command::new("cargo")
+        .args(["run", "-p", "agm", "--", "init", "-C"])
+        .arg(tmp.path())
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "init failed: {:?}", output);
+    let manifest = tmp.path().join("agm.json");
+    assert!(manifest.exists(), "agm.json not created");
+}
+
+#[test]
+fn test_install_without_manifest_fails() {
+    let tmp = TempDir::new().unwrap();
+    let output = Command::new("cargo")
+        .args([
+            "run", "-p", "agm", "--", "install", "--tool", "claude", "-C",
+        ])
+        .arg(tmp.path())
+        .output()
+        .unwrap();
+
+    assert!(
+        !output.status.success(),
+        "install should fail without agm.json"
+    );
+}
+
+#[test]
+fn test_init_then_list() {
+    let tmp = TempDir::new().unwrap();
+
+    let output = Command::new("cargo")
+        .args(["run", "-p", "agm", "--", "init", "-C"])
+        .arg(tmp.path())
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+
+    let output = Command::new("cargo")
+        .args(["run", "-p", "agm", "--", "list", "-C"])
+        .arg(tmp.path())
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+}
+
+#[test]
+fn test_help_output() {
+    let output = Command::new("cargo")
+        .args(["run", "-p", "agm", "--", "--help"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("init"), "help should mention init");
+    assert!(stdout.contains("install"), "help should mention install");
+    assert!(
+        stdout.contains("uninstall"),
+        "help should mention uninstall"
+    );
+    assert!(stdout.contains("list"), "help should mention list");
+    assert!(stdout.contains("update"), "help should mention update");
+    assert!(stdout.contains("publish"), "help should mention publish");
+    assert!(stdout.contains("gc"), "help should mention gc");
+}

--- a/docs/blogs/persona-boost/persona-boost.md
+++ b/docs/blogs/persona-boost/persona-boost.md
@@ -1,6 +1,6 @@
 # Claude 的人格能提升别的模型智商——SWE-bench 实测涨 11 个点
 
-> **[CC_Pure (CCP)](https://github.com/James-FE/CC_Pure)** — 基于 [Claude Code Best (CCB)](https://github.com/claude-code-best/claude-code) 的开源增强实现，支持自定义 Persona、权限控制和多模型调度。<https://github.com/James-FE/CC_Pure>
+> **[CC_Pure (CCP)](https://github.com/GhostDragon124/CC_Pure)** — 基于 [Claude Code Best (CCB)](https://github.com/claude-code-best/claude-code) 的开源增强实现，支持自定义 Persona、权限控制和多模型调度。<https://github.com/GhostDragon124/CC_Pure>
 
 DeepSeek V4 Pro 加 CCP 工具链，90 个 SWE-bench Lite 实例分两组跑，结果差了 11 个百分点。
 
@@ -70,5 +70,5 @@ django 上的差距更系统化。37 个实例，Default 解了 56.8%，Persona 
 完整报告和 Claude Persona 定义都在 CC_Pure 仓库。
 
 CCP 基于 Claude Code Best：<https://github.com/claude-code-best/claude-code>
-项目地址：[github.com/James-FE/CC_Pure](https://github.com/James-FE/CC_Pure)
-完整报告：[ccp-claude-persona-swebench-report-v2.md](https://github.com/James-FE/CC_Pure/blob/main/docs/ccp-claude-persona-swebench-report-v2.md)
+项目地址：[github.com/GhostDragon124/CC_Pure](https://github.com/GhostDragon124/CC_Pure)
+完整报告：[ccp-claude-persona-swebench-report-v2.md](https://github.com/GhostDragon124/CC_Pure/blob/main/docs/ccp-claude-persona-swebench-report-v2.md)


### PR DESCRIPTION
agm is a pnpm-style package manager for AI agent dependencies. Key features:
- agm.json + agm.lock.json manifest format
- Two-tier dependency model (git commit hash + registry semver)
- Tool-agnostic adapter pattern (Claude, Codex, Copilot)
- Content-addressable store (~/.agm/store/) with atomic install
- Recursive auto-detection of skills/agents from repos
- CLI: init, install (--git/--tool), uninstall, list, update, gc, self-update
- Install scripts for Unix (curl|bash) and Windows (irm|iex)
- CI/CD: GitHub Actions multi-platform build on agm-v* tags

feat(agm): add Agent Package Manager CLI tool

agm is a pnpm-style package manager for AI agent dependencies. Key features:
- agm.json + agm.lock.json manifest format
- Two-tier dependency model (git commit hash + registry semver)
- Tool-agnostic adapter pattern (Claude, Codex, Copilot)
- Content-addressable store (~/.agm/store/) with atomic install
- Recursive auto-detection of skills/agents from repos
- CLI: init, install (--git/--tool), uninstall, list, update, gc, self-update
- Install scripts for Unix (curl|bash) and Windows (irm|iex)
- CI/CD: GitHub Actions multi-platform build on agm-v* tags