### PR TITLE
feat(peri-web-pty): 支持 --host 和 --port 命令行参数

### DIFF
--- a/peri-tui/src/main.rs
+++ b/peri-tui/src/main.rs
@@ -167,7 +167,14 @@ enum Commands {
         action: PluginAction,
     },
     /// 启动 Web PTY 终端服务
-    Web,
+    Web {
+        /// 监听地址（默认 0.0.0.0，监听所有网卡）
+        #[arg(long, default_value = "0.0.0.0", env = "HOST")]
+        host: String,
+        /// 监听端口（默认 0 = 随机分配）
+        #[arg(long, default_value_t = 0, env = "PORT")]
+        port: u16,
+    },
 }
 
 #[derive(Subcommand)]
@@ -419,15 +426,20 @@ fn main() -> Result<()> {
                 }
             })
         }
-        Some(Commands::Web) => {
+        Some(Commands::Web { host, port }) => {
+            let mut config = peri_web_pty::config::Config::from_env();
+            config.host = host;
+            config.port = port;
+            // peri web 模式下默认启动 peri 对话
+            if config.initial_cmd.is_none() {
+                config.initial_cmd = Some("peri".to_string());
+            }
             let rt = build_runtime()?;
-            rt.block_on(async {
-                peri_web_pty::start_server(peri_web_pty::config::Config::from_env()).await
-            })
-            .map_err(|e| {
-                eprintln!("Web PTY server error: {e:#}");
-                std::process::exit(1);
-            })
+            rt.block_on(async { peri_web_pty::start_server(config).await })
+                .map_err(|e| {
+                    eprintln!("Web PTY server error: {e:#}");
+                    std::process::exit(1);
+                })
         }
     }
 }

--- a/peri-web-pty/src/config.rs
+++ b/peri-web-pty/src/config.rs
@@ -4,6 +4,10 @@ use clap::Parser;
 #[derive(Debug, Clone, Parser)]
 #[command(name = "peri-web-pty", about = "Web PTY terminal server")]
 pub struct Config {
+    /// 监听地址（默认 0.0.0.0，监听所有网卡）
+    #[arg(long, env = "HOST", default_value = "0.0.0.0")]
+    pub host: String,
+
     /// 监听端口（默认 0 = 随机分配）
     #[arg(long, env = "PORT", default_value_t = 0)]
     pub port: u16,
@@ -39,6 +43,7 @@ impl Config {
     /// 默认 initial_cmd 为 "peri"（自动进入 Peri 对话）。
     pub fn from_env() -> Self {
         Self {
+            host: std::env::var("HOST").unwrap_or_else(|_| "0.0.0.0".to_string()),
             port: std::env::var("PORT")
                 .ok()
                 .and_then(|p| p.parse().ok())

--- a/peri-web-pty/src/config_test.rs
+++ b/peri-web-pty/src/config_test.rs
@@ -3,6 +3,42 @@ use serial_test::serial;
 
 #[test]
 #[serial]
+fn test_config_from_args_uses_host_env_when_set() {
+    unsafe {
+        std::env::set_var("HOST", "127.0.0.1");
+    }
+    let cfg = Config::parse_from(["peri-web-pty"]);
+    assert_eq!(cfg.host, "127.0.0.1");
+    unsafe {
+        std::env::remove_var("HOST");
+    }
+}
+
+#[test]
+#[serial]
+fn test_config_from_args_defaults_host_when_unset() {
+    unsafe {
+        std::env::remove_var("HOST");
+    }
+    let cfg = Config::parse_from(["peri-web-pty"]);
+    assert_eq!(cfg.host, "0.0.0.0");
+}
+
+#[test]
+#[serial]
+fn test_config_from_args_host_cli_override() {
+    unsafe {
+        std::env::set_var("HOST", "0.0.0.0");
+    }
+    let cfg = Config::parse_from(["peri-web-pty", "--host", "127.0.0.1"]);
+    assert_eq!(cfg.host, "127.0.0.1");
+    unsafe {
+        std::env::remove_var("HOST");
+    }
+}
+
+#[test]
+#[serial]
 fn test_config_from_args_uses_port_env_when_set() {
     unsafe {
         std::env::set_var("PORT", "9090");
@@ -54,12 +90,14 @@ fn test_config_from_args_uses_cmd_when_set() {
 #[serial]
 fn test_config_from_args_defaults_when_all_unset() {
     unsafe {
+        std::env::remove_var("HOST");
         std::env::remove_var("PORT");
         std::env::remove_var("SHELL");
         std::env::remove_var("CWD");
         std::env::remove_var("CMD");
     }
     let cfg = Config::parse_from(["peri-web-pty"]);
+    assert_eq!(cfg.host, "0.0.0.0");
     assert_eq!(cfg.port, 0);
     assert!(cfg.shell.is_none());
     assert!(cfg.cwd.is_none());

--- a/peri-web-pty/src/lib.rs
+++ b/peri-web-pty/src/lib.rs
@@ -34,7 +34,7 @@ pub async fn start_server(config: Config) -> anyhow::Result<()> {
         .route("/ws", axum::routing::get(ws_handler::ws_handler))
         .with_state(state);
 
-    let addr = format!("0.0.0.0:{}", config.port);
+    let addr = format!("{}:{}", config.host, config.port);
     let listener = tokio::net::TcpListener::bind(&addr)
         .await
         .context("failed to bind TCP listener")?;


### PR DESCRIPTION
- config.rs: 新增 --host 字段，默认 0.0.0.0，支持 HOST 环境变量
- lib.rs: start_server() 使用 config.host 替代硬编码
- peri-tui/main.rs: Commands::Web 接收 --host/--port，替代纯 env 读取
- config_test.rs: 新增 host 相关测试（env 读取/默认值/CLI 覆盖）