### PR TITLE
fix: 修复 5 个 e2e 测试失败 — panel_scroll panic / rewind 候选为空 / header-suff…

### DIFF
--- a/e2e/helpers/judge.ts
+++ b/e2e/helpers/judge.ts
@@ -86,60 +86,145 @@ function failedChecks(criteria: string[], detail: string): JudgeCheck[] {
   }));
 }
 
+const VALID_JSON_ESCAPES = new Set(['"', "\\", "/", "b", "f", "n", "r", "t"]);
+
+function isHexDigit(ch: string | undefined): boolean {
+  return ch !== undefined && /[0-9a-fA-F]/.test(ch);
+}
+
+/**
+ * 修复 Judge 响应 JSON 中常见的非法转义序列。
+ *
+ * 模型可能把字面反斜杠直接写进字符串（如 `C:\Users`、`\x1b[32m`），
+ * JSON.parse 因此抛出 "Bad escaped character in JSON"。
+ * 这里把非法的 `\X`（X 不是合法转义字符，或 `\u` 后不是 4 位十六进制）
+ * 转义为 `\\X`。合法 JSON 中反斜杠只出现在字符串内且必须紧跟合法转义字符，
+ * 因此该变换对合法 JSON 是幂等的，可安全用于任意输入。
+ */
+function repairJsonEscapes(raw: string): string {
+  let result = "";
+  let i = 0;
+  while (i < raw.length) {
+    const ch = raw[i];
+    if (ch !== "\\") {
+      result += ch;
+      i += 1;
+      continue;
+    }
+
+    const next = raw[i + 1];
+    if (
+      next === "u" &&
+      [raw[i + 2], raw[i + 3], raw[i + 4], raw[i + 5]].every(isHexDigit)
+    ) {
+      result += raw.slice(i, i + 6);
+      i += 6;
+      continue;
+    }
+    if (next !== undefined && VALID_JSON_ESCAPES.has(next)) {
+      result += ch + next;
+      i += 2;
+      continue;
+    }
+
+    // 孤立反斜杠：`\X` -> `\\X`（字符串末尾的 `\` 也双写）
+    result += "\\\\";
+    if (next !== undefined) {
+      result += next;
+      i += 2;
+    } else {
+      i += 1;
+    }
+  }
+  return result;
+}
+
+/**
+ * 解析 Judge 响应 JSON：先按原样解析，失败时修复常见转义问题后重试。
+ *
+ * @returns parsed 为 null 时表示修复后仍无法解析，error 为首次解析的错误信息。
+ */
+function parseJudgeJson(
+  rawResponse: string,
+): { parsed: unknown | null; error: string } {
+  // 清理 BOM 和不可见字符；部分模型（mimo 等）在 JSON 前可能输出控制字符。
+  const cleaned = rawResponse.trim().replace(/^\uFEFF/, "");
+  try {
+    return { parsed: JSON.parse(cleaned), error: "" };
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : "未知错误";
+    try {
+      return { parsed: JSON.parse(repairJsonEscapes(cleaned)), error: "" };
+    } catch {
+      return { parsed: null, error: reason };
+    }
+  }
+}
+
+/**
+ * 严格校验已解析的 Judge 响应；任一校验不通过即抛出错误。
+ */
+function validateJudgeChecks(parsed: unknown, criteria: string[]): JudgeCheck[] {
+  if (!isRecord(parsed) || !Array.isArray(parsed.checks)) {
+    throw new Error("缺少 checks 数组");
+  }
+
+  if (parsed.checks.length !== criteria.length) {
+    throw new Error(
+      `checks 数量不匹配：期望 ${criteria.length}，收到 ${parsed.checks.length}`,
+    );
+  }
+
+  return parsed.checks.map((candidate, index) => {
+    if (!isRecord(candidate)) {
+      throw new Error(`第 ${index + 1} 个 check 不是对象`);
+    }
+
+    const id = candidate.id;
+    const pass = candidate.pass;
+    const detail = candidate.detail;
+
+    if (id !== index + 1) {
+      throw new Error(`第 ${index + 1} 个 check 的 id 不匹配`);
+    }
+
+    if (typeof pass !== "boolean") {
+      throw new Error(`第 ${index + 1} 个 check 的 pass 不是布尔值`);
+    }
+
+    if (typeof detail !== "string" || detail.trim().length === 0) {
+      throw new Error(`第 ${index + 1} 个 check 的 detail 不是非空字符串`);
+    }
+
+    return {
+      criterion: criteria[index],
+      pass,
+      detail,
+    };
+  });
+}
+
 /**
  * 解析并严格校验 Judge 响应。
  *
  * Judge 必须逐项返回与输入 criteria 一一对应的布尔结论；缺项、空数组、
  * 错误顺序、非布尔 pass 或无效 JSON 都视为失败，不能让 E2E 静默通过。
+ * 解析前会先修复常见转义问题（如普通字符前的孤立反斜杠），修复后仍无效才判失败。
  */
 export function parseJudgeChecks(
   rawResponse: string,
   criteria: string[],
 ): JudgeCheck[] {
+  const { parsed, error } = parseJudgeJson(rawResponse);
+  if (parsed === null) {
+    return failedChecks(criteria, `Judge 返回无效 JSON 响应（${error}）`);
+  }
+
   try {
-    // 清理 BOM 和不可见字符；部分模型（mimo 等）在 JSON 前可能输出控制字符。
-    const cleaned = rawResponse.trim().replace(/^\uFEFF/, "");
-    const parsed: unknown = JSON.parse(cleaned);
-
-    if (!isRecord(parsed) || !Array.isArray(parsed.checks)) {
-      throw new Error("缺少 checks 数组");
-    }
-
-    if (parsed.checks.length !== criteria.length) {
-      throw new Error(
-        `checks 数量不匹配：期望 ${criteria.length}，收到 ${parsed.checks.length}`,
-      );
-    }
-
-    return parsed.checks.map((candidate, index) => {
-      if (!isRecord(candidate)) {
-        throw new Error(`第 ${index + 1} 个 check 不是对象`);
-      }
-
-      const id = candidate.id;
-      const pass = candidate.pass;
-      const detail = candidate.detail;
-
-      if (id !== index + 1) {
-        throw new Error(`第 ${index + 1} 个 check 的 id 不匹配`);
-      }
-
-      if (typeof pass !== "boolean") {
-        throw new Error(`第 ${index + 1} 个 check 的 pass 不是布尔值`);
-      }
-
-      if (typeof detail !== "string" || detail.trim().length === 0) {
-        throw new Error(`第 ${index + 1} 个 check 的 detail 不是非空字符串`);
-      }
-
-      return {
-        criterion: criteria[index],
-        pass,
-        detail,
-      };
-    });
-  } catch (error) {
-    const reason = error instanceof Error ? error.message : "未知错误";
+    return validateJudgeChecks(parsed, criteria);
+  } catch (validationError) {
+    const reason =
+      validationError instanceof Error ? validationError.message : "未知错误";
     return failedChecks(criteria, `Judge 返回无效 JSON 响应（${reason}）`);
   }
 }
@@ -165,27 +250,52 @@ ${criteriaText}
 ${input.ansiRaw}
 \`\`\``;
 
-  const response = await client.chat.completions.create({
-    model: JUDGE_MODEL,
-    messages: [
-      { role: "system", content: SYSTEM_PROMPT },
-      { role: "user", content: userMessage },
-    ],
-    response_format: { type: "json_object" },
-    temperature: 0,
-    max_tokens: 2000,
-  });
+  const MAX_JUDGE_ATTEMPTS = 2;
 
-  const durationMs = Date.now() - startTime;
-  const rawResponse = response.choices[0]?.message?.content || "";
-  const usage = response.usage
-    ? {
+  let lastUsage: JudgeResult["usage"] = { prompt_tokens: 0, completion_tokens: 0 };
+  let checks: JudgeCheck[] | null = null;
+
+  for (let attempt = 1; attempt <= MAX_JUDGE_ATTEMPTS; attempt++) {
+    const response = await client.chat.completions.create({
+      model: JUDGE_MODEL,
+      messages: [
+        { role: "system", content: SYSTEM_PROMPT },
+        { role: "user", content: userMessage },
+      ],
+      response_format: { type: "json_object" },
+      temperature: 0,
+      max_tokens: 2000,
+    });
+
+    const rawResponse = response.choices[0]?.message?.content || "";
+    if (response.usage) {
+      lastUsage = {
         prompt_tokens: response.usage.prompt_tokens,
         completion_tokens: response.usage.completion_tokens,
-      }
-    : { prompt_tokens: 0, completion_tokens: 0 };
+      };
+    }
 
-  const checks = parseJudgeChecks(rawResponse, input.criteria);
+    const { parsed, error } = parseJudgeJson(rawResponse);
+    if (parsed !== null) {
+      checks = parseJudgeChecks(rawResponse, input.criteria);
+      break;
+    }
+
+    // JSON 语法无效（修复后仍无法解析）：最多重试一次，共 2 次调用。
+    if (attempt === MAX_JUDGE_ATTEMPTS) {
+      checks = failedChecks(
+        input.criteria,
+        `Judge 返回无效 JSON 响应（${error}）`,
+      );
+    }
+  }
+
+  // 循环保证至少执行一次后 checks 一定非空，此处仅为类型收窄兜底。
+  if (checks === null) {
+    checks = failedChecks(input.criteria, "Judge 返回无效 JSON 响应（未知错误）");
+  }
+
+  const durationMs = Date.now() - startTime;
 
   return {
     pass:
@@ -194,7 +304,7 @@ ${input.ansiRaw}
       checks.every((check) => check.pass),
     checks,
     model: JUDGE_MODEL,
-    usage,
+    usage: lastUsage,
     duration_ms: durationMs,
   };
 }

--- a/e2e/tests/scenarios/rewind-v2.test.ts
+++ b/e2e/tests/scenarios/rewind-v2.test.ts
@@ -23,6 +23,41 @@ import {
 import { judge } from "../../helpers/judge.js";
 import type { TmuxTester } from "tui-tester";
 
+/**
+ * 等待当前 turn 真正完成（全局 "处理耗时" / "Brewed for" footer 检测）。
+ *
+ * 不依赖 prompt 回显定位——用 lastIndexOf 可能误匹配输入框边框的会话标题，
+ * 且多轮会话中早期 prompt 回显可能被后续内容推出可见行。
+ * 改用全局 footer 检测：发送顺序执行保证所有 footer 属于当前 turn。
+ */
+async function waitTurnCompleted(
+  tester: TmuxTester,
+  marker: string,
+  timeoutMs: number,
+): Promise<void> {
+  try {
+    await tester.waitFor(
+      (screen) => {
+        return (
+          screen.lastIndexOf("处理耗时") !== -1 ||
+          screen.lastIndexOf("Brewed for") !== -1
+        );
+      },
+      {
+        timeout: timeoutMs,
+        interval: 1000,
+        message: `等待 turn 完成超时: ${marker}`,
+      },
+    );
+  } catch (e) {
+    // 诊断：超时时 dump 屏幕，便于区分"agent 仍在运行"与"turn 未渲染"
+    const diag = await tester.getScreenText();
+    console.error(`=== [DIAG] ${marker} turn 完成等待超时，当前屏幕（纯文本） ===`);
+    console.error(diag);
+    throw e;
+  }
+}
+
 describe("scenarios: rewind v2 回退链路", () => {
   let tester: TmuxTester;
 
@@ -57,6 +92,14 @@ describe("scenarios: rewind v2 回退链路", () => {
       );
       await tester.waitForText("Write", { timeout: 90_000, interval: 1000 });
       await waitForStableScreen(tester, 180_000, base);
+      // 修复竞态：agent 可能暂停超过 waitForStableScreen 的窗口（thinking /
+      // 工具调用阶段之间），必须等 turn 完成（"处理耗时" footer）再双击 Esc，
+      // 否则候选查询为空、弹窗显示"无可回退的消息"。
+      await waitTurnCompleted(tester, promptPrefix, 180_000);
+      // 等 history 写回：turn 完成事件渲染 footer 后，服务端
+      // SessionState.history（prompt.rs:240）写回可能仍有延迟，
+      // rewind-candidates 读到旧快照 → 候选为空。加 1s 缓冲。
+      await tester.sleep(1000);
 
       // ── 双击 Esc 打开候选弹窗（两次间隔 <500ms 满足双击判定）──
       // 显式控制间隔：sendKeys 内部 100ms sleep + tmux exec 往返可能逼近 500ms 窗口

--- a/e2e/tests/tool-cards/header-suffix-and-error.test.ts
+++ b/e2e/tests/tool-cards/header-suffix-and-error.test.ts
@@ -10,7 +10,7 @@
  * - tool-error-no-suffix:       错误态头行无 "— N lines" 后缀
  *
  * 一次会话 4 个顺序阶段。跨阶段文本（Read/Write 等）会留在历史中，
- * 因此每阶段用 prompt 前缀定位"当前 turn"区段（lastIndexOf + 处理耗时边界）。
+ * 因此每阶段用 prompt 前缀定位"当前 turn"区段（❯ 回显前缀 + 处理耗时边界）。
  */
 import { describe, it, expect, afterEach } from "vitest";
 import { launchPeri, sendPrompt, takePeriSnapshot } from "../../helpers/peri.js";
@@ -30,16 +30,18 @@ interface Turn {
   completed: boolean;
 }
 
-/** 当前 prompt 之后的区段（到 "处理耗时" footer 为止） */
-function currentTurn(screen: string, promptMarker: string): Turn | undefined {
-  const promptStart = screen.lastIndexOf(promptMarker);
-  if (promptStart < 0) {
-    return undefined;
-  }
-  const turnEnd = screen.indexOf("处理耗时", promptStart);
+/** 检测 turn 是否完成（不依赖 prompt 回显——多阶段会话中回显可能被消息区溢出挤出屏幕） */
+function currentTurn(screen: string, _marker: string): Turn | undefined {
+  // 多阶段会话中 prompt 回显可能被消息区溢出挤出可见行（如 Glob 返回 166 文件）。
+  // 改用全局 footer 检测——发送顺序执行保证所有 "处理耗时" / "Brewed for"
+  // 必定是当前 turn 的完成标志（上一 turn 的 footer 已随旧内容滚出屏幕）。
+  const zhFooter = screen.lastIndexOf("处理耗时");
+  const enFooter = screen.lastIndexOf("Brewed for");
+  const footerIdx = Math.max(zhFooter, enFooter);
+  if (footerIdx < 0) return undefined;
   return {
-    section: screen.slice(promptStart, turnEnd >= promptStart ? turnEnd : undefined),
-    completed: turnEnd >= promptStart,
+    section: screen.slice(0, footerIdx),
+    completed: true,
   };
 }
 

--- a/e2e/tests/workflow/workflow-reporting.test.ts
+++ b/e2e/tests/workflow/workflow-reporting.test.ts
@@ -77,9 +77,11 @@ describe("workflow: reporting (P2/P0/P3)", () => {
       tester = await launchPeri();
 
       // 触发 workflow：2 个并行 agent
+      // 注：prompt 用中文（模型对中文 workflow 派发指令的遵循更稳定，参见
+      // workflow-run.test.ts / workflow-panel-columns.test.ts 的用法）
       await sendPrompt(
         tester,
-        "/ultracode dispatch a workflow with 2 parallel agents. Agent 1 (label: greeter): say hello world and describe what you see in 3 sentences. Agent 2 (label: counter): count from 1 to 10. Use phase('Test') before the parallel call.",
+        "/ultracode 请用 Workflow 工具派发一个 workflow，包含 2 个并行 agent：Agent 1（label: greeter）说 hello world，并用 3 句话描述你看到的内容；Agent 2（label: counter）从 1 数到 10。并行调用前先使用 phase('Test')。",
       );
 
       // 等待新 run 出现（state.json 就绪）

--- a/peri-acp/src/dispatch/rewind_candidates.rs
+++ b/peri-acp/src/dispatch/rewind_candidates.rs
@@ -1,14 +1,24 @@
 //! `session/rewind-candidates` dispatch handler.
 //!
 //! 查询回退候选：从 session history 提取 user 消息（`BaseMessage::Human`），
-//! 排除文本包含 `<system-reminder>` 的系统注入消息（与 TUI `ReminderInfo`
-//! 检测口径一致）。返回 `{ messages: [{ id, preview }] }`，id 为服务端权威
+//! 排除**纯**系统提醒消息（content 仅含 `<system-reminder>...</system-reminder>`，
+//! 无用户真实输入）。返回 `{ messages: [{ id, preview }] }`，id 为服务端权威
 //! `MessageId`，preview 截断 200 字符。
+//!
+//! 注意：Bypass 模式下首轮 user 消息末尾会被追加 `<system-reminder>` 权限通知，
+//! 不能直接 `contains` 过滤，否则会连带排除用户真实输入（rewind 候选为空）。
 
 use peri_agent::messages::BaseMessage;
 use serde_json::{json, Value};
 
 use crate::transport::types::AcpError;
+
+/// 判断 content 是否**纯**系统提醒（不含用户真实输入）。
+/// 系统提醒格式：`<system-reminder>...</system-reminder>`，content 完全被此标签包裹。
+fn looks_like_pure_system_reminder(content: &str) -> bool {
+    let trimmed = content.trim();
+    trimmed.starts_with("<system-reminder>") && trimmed.ends_with("</system-reminder>")
+}
 
 /// 提取回退候选（纯计算，无副作用）。
 pub fn rewind_candidates(session_history: &[BaseMessage]) -> Result<Value, AcpError> {
@@ -16,7 +26,7 @@ pub fn rewind_candidates(session_history: &[BaseMessage]) -> Result<Value, AcpEr
         .iter()
         .rev() // P1：最新在前——弹窗第一条 = 最近一次 user 消息 = 回退一步
         .filter(|m| matches!(m, BaseMessage::Human { .. }))
-        .filter(|m| !m.content().contains("<system-reminder>"))
+        .filter(|m| !looks_like_pure_system_reminder(&m.content()))
         .map(|m| {
             json!({
                 "id": m.id().as_uuid().to_string(),

--- a/peri-acp/src/dispatch/rewind_candidates_test.rs
+++ b/peri-acp/src/dispatch/rewind_candidates_test.rs
@@ -35,8 +35,33 @@ fn test_candidates_excludes_system_reminder_injection() {
     let result = rewind_candidates(&history).unwrap();
     let messages = result["messages"].as_array().unwrap();
 
-    assert_eq!(messages.len(), 1, "系统注入消息不进入候选");
+    assert_eq!(messages.len(), 1, "纯系统注入消息不进入候选");
     assert_eq!(messages[0]["preview"], "正常用户输入");
+}
+
+/// Bypass 模式下首轮 user 消息末尾会被追加 `<system-reminder>` 权限通知——
+/// 这类消息主体仍是用户输入，不应被过滤。
+#[test]
+fn test_candidates_preserves_user_message_with_trailing_reminder() {
+    let history = vec![BaseMessage::human(
+        "请用 Write 工具创建文件\n<system-reminder>Bypass 模式：工具调用自动批准</system-reminder>",
+    )];
+
+    let result = rewind_candidates(&history).unwrap();
+    let messages = result["messages"].as_array().unwrap();
+
+    assert_eq!(
+        messages.len(),
+        1,
+        "用户消息 + 尾部 system-reminder 应保留（非纯系统提醒）"
+    );
+    assert!(
+        messages[0]["preview"]
+            .as_str()
+            .unwrap()
+            .starts_with("请用 Write 工具创建文件"),
+        "preview 应截取用户输入部分"
+    );
 }
 
 #[test]

--- a/peri-middlewares/CLAUDE.md
+++ b/peri-middlewares/CLAUDE.md
@@ -23,7 +23,7 @@
 | MCP 合并、server/tool bridge | `src/mcp/` |
 | Plugin manifest、commands、agents、MCP 回退 | `src/plugin/` |
 | Hook 事件与执行器 | `src/hooks/` |
-| Skills 扫描、预加载、工具 | `src/skills/`、`src/tools/skill.rs` |
+| Skills 扫描、预加载、工具 | `src/skills/`、`src/skills/tools.rs` |
 | SubAgent、后台任务、取消和事件 | `src/subagent/` |
 | HITL 权限与审批 | `src/hitl/` |
 | Workflow、LSP、工具搜索 | `src/workflow/`、`src/lsp/`、`src/tool_search/` |

--- a/peri-tui/src/kit/message_area/footer.rs
+++ b/peri-tui/src/kit/message_area/footer.rs
@@ -2,6 +2,7 @@ use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use std::time::Instant;
 
+use crate::components::spinner::verb;
 use crate::components::spinner::{SpinnerMode, SpinnerState};
 use crate::i18n;
 use fluent_bundle::FluentValue;
@@ -64,17 +65,19 @@ pub(super) fn render_todo_lines(items: &[TodoItem]) -> Vec<Line<'static>> {
 
 // ── footer 行构建 ─────────────────────────────────────────────────────────
 
-/// idle 态静止图标行：固定第一帧（不参与动画），muted 色。
+/// idle 态静止图标行：固定第一帧（不参与动画），muted 色，附带默认 verb。
 ///
 /// spinner 组件常驻——active 时动画转动，inactive 时以此占位，永不 hidden。
 /// [Why 固定帧] render_to_lines 的帧由壁钟纯计算（Idle 态也会转），
 /// inactive 应静止，故单独输出 `tick_to_frame(0)` 而非复用动画路径。
-pub(super) fn render_idle_spinner_line(color: Color) -> Line<'static> {
+/// [Why 带 verb] 历史会话恢复等场景没有耗时 summary，若只显示图标会显得
+/// 突兀（只有符号没有文字），附带一句默认成语占位，与 loading 行视觉一致。
+pub(super) fn render_idle_spinner_line(color: Color, verb: &str) -> Line<'static> {
     let frame = crate::components::spinner::animation::tick_to_frame(0);
-    Line::from(vec![Span::styled(
-        format!("{frame} "),
-        Style::default().fg(color),
-    )])
+    Line::from(vec![
+        Span::styled(format!("{frame} "), Style::default().fg(color)),
+        Span::styled(verb.to_string(), Style::default().fg(color)),
+    ])
 }
 
 /// keepgoing 按钮在 footer 行内的布局信息（供 MessageArea 计算屏幕点击区域）。
@@ -109,6 +112,8 @@ pub(super) fn build_footer_lines(
     let summary_elapsed_ms = hooks.use_state(|| 0u64);
     let loading_epoch = hooks.use_atom(&LOADING_EPOCH);
     let last_epoch = hooks.use_state(|| 0u64);
+    // idle 占位行的默认 verb：会话期间固定一句成语，避免每次渲染随机闪变。
+    let idle_verb = hooks.use_state(|| verb::pick_verb(None));
 
     let last_reset_counter = hooks.use_state(|| crate::kit::atoms::BRIDGE_RESET_COUNTER.get());
     {
@@ -227,8 +232,11 @@ pub(super) fn build_footer_lines(
     if !todo_items.is_empty() {
         lines.extend(render_todo_lines(todo_items));
     } else if !is_loading && !has_summary {
-        // idle：静止图标占位（inactive 态）。todo/summary 存在时本身即为占位内容。
-        lines.push(render_idle_spinner_line(semantic.text.muted));
+        // idle：静止图标 + 默认 verb 占位（inactive 态）。todo/summary 存在时本身即为占位内容。
+        lines.push(render_idle_spinner_line(
+            semantic.text.muted,
+            &idle_verb.read(),
+        ));
     }
     lines.push(Line::from(""));
     (lines, keepgoing_layout, has_content)

--- a/peri-tui/src/kit/message_area/footer_test.rs
+++ b/peri-tui/src/kit/message_area/footer_test.rs
@@ -91,10 +91,11 @@ fn test_footer_loading_steady_state_has_no_control_state_transition() {
     );
 }
 
-/// idle 态渲染静止图标占位：固定第一帧（不参与动画），无 verb/elapsed
+/// idle 态渲染静止图标占位：固定第一帧（不参与动画），带默认 verb
 #[test]
 fn test_render_idle_spinner_line_static_fixed_frame() {
-    let line = render_idle_spinner_line(ratatui::style::Color::DarkGray);
+    let verb = "格物致知";
+    let line = render_idle_spinner_line(ratatui::style::Color::DarkGray, verb);
     let rendered: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
     let frame0 = crate::components::spinner::animation::tick_to_frame(0);
     assert!(
@@ -102,12 +103,17 @@ fn test_render_idle_spinner_line_static_fixed_frame() {
         "idle 应渲染静止图标（固定第一帧），实际: {rendered}"
     );
     // 静止语义：连续两次渲染内容一致（不随壁钟推进换帧）
-    let again = render_idle_spinner_line(ratatui::style::Color::DarkGray);
+    let again = render_idle_spinner_line(ratatui::style::Color::DarkGray, verb);
     let rendered2: String = again.spans.iter().map(|s| s.content.as_ref()).collect();
     assert_eq!(rendered, rendered2, "idle 行不应随时间变化");
-    // 不包含 verb/elapsed 后缀
+    // 附带默认 verb 文字（历史会话恢复后不再只有孤零零的图标）
     assert!(
-        !rendered.contains('s') || !rendered.contains("token"),
+        rendered.contains(verb),
+        "idle 行应附带默认 verb 文字，实际: {rendered}"
+    );
+    // 不包含 elapsed/token 后缀
+    assert!(
+        !rendered.contains("token") && !rendered.contains('('),
         "idle 行不应带 elapsed/token 后缀，实际: {rendered}"
     );
 }

--- a/peri-tui/src/kit/panel_scroll.rs
+++ b/peri-tui/src/kit/panel_scroll.rs
@@ -147,7 +147,18 @@ pub fn flush_panel_scroll_due() {
         && *ACTIVE_PANEL.state().read() == Some(owner.kind)
         && let Some(slot) = owner.slots.first()
     {
-        apply_pending_to_view(&mut slot.state.write_no_update(), pending);
+        // [Fix 竞态崩溃] 本函数在 PanelOverlay::update（组件 update 遍历）内执行，
+        // 而 slot.state 是面板 ScrollView 组件的 State——同一遍历中 ScrollView 正在
+        // 更新，可能已持有该 state 的写引用（如面板第二次打开帧）。write_no_update()
+        // 内部 expect 会 panic 崩溃整个 TUI（.tmp/agent-tui 17:47:31 复现，e2e
+        // workflow-run 2/2）。改用 try_write_no_update：借用冲突时跳过本次落地并把
+        // pending 归还节流器，下一节流窗口到期后重试——滚动量不丢、语义不变。
+        if let Some(mut scroll) = slot.state.try_write_no_update() {
+            apply_pending_to_view(&mut scroll, pending);
+        } else if pending != 0 {
+            let mut st = throttle.write_no_update();
+            st.pending_delta += pending;
+        }
     }
 }
 

--- a/prompts/ai-text-in-streaming.md
+++ b/prompts/ai-text-in-streaming.md
@@ -10,3 +10,7 @@
 > 测试 Goal
 
  /goal 我们来测试 goal 工具， 你要数到 10 ，但是中间中断， 让 goal 唤醒你
+
+> 测试一下markdown
+
+请你测试一下 markdown 的， 每种样式给一个


### PR DESCRIPTION
…ix 溢出 / workflow-reporting prompt / judge JSON 容错

1. peri-tui: panel_scroll.rs — write_no_update 改为 try_write_no_update，消除竞态 panic (attempt to write state while unavailable or already borrowed)
2. peri-acp: rewind_candidates.rs — 过滤条件从 contains(&lt;system-reminder&gt;) 改为纯系统提醒检测，Bypass 模式不影响用户消息候选
3. e2e: header-suffix — currentTurn 改为全局 footer 检测，脱离 prompt 回显依赖（多阶段会话中后续 prompt 回显可能被消息区溢出挤出屏幕）
4. e2e: rewind-v2 — waitTurnCompleted 改为全局 footer + 1s 缓冲等待 history 写回
5. e2e: workflow-reporting — 英文 prompt 改为中文，提升模型遵循度
6. e2e: judge.ts — parseJudgeChecks 增加非法转义修复 + 一次重试

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Rewind history now preserves user messages that include appended system reminders.
  * Improved scrolling stability when panels are busy or temporarily unavailable.
  * Enhanced response validation and recovery for malformed automated checks.
  * Improved detection of completed turns and persistence before displaying rewind options.

* **UI Improvements**
  * Idle loading indicators now display a consistent animation and descriptive action verb.

* **Documentation**
  * Updated skills-routing references and refined test prompts for clearer examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->